### PR TITLE
new: added ParseWith which parses args with configs

### DIFF
--- a/parse-with.go
+++ b/parse-with.go
@@ -12,34 +12,34 @@ type /* error reason */ (
 	// ConfigIsArrayButHasNoParam is an error reason which indicates that
 	// an option configuration contradicts that the option must be an array
 	// (.IsArray = true) but must have no option parameter (.HasParam = false).
-	ConfigIsArrayButHasNoParam struct{ Opt string }
+	ConfigIsArrayButHasNoParam struct{ Option string }
 
 	// ConfigHasDefaultButHasNoParam is an error reason which indicates that
 	// an option configuration contradicts that the option has default value
 	// (.Default != nil) but must have no option parameter (.HasParam = false).
-	ConfigHasDefaultButHasNoParam struct{ Opt string }
+	ConfigHasDefaultButHasNoParam struct{ Option string }
 
 	// UnconfiguredOption is an error reason which indicates that there is no
 	// configuration about the input option.
-	UnconfiguredOption struct{ Opt string }
+	UnconfiguredOption struct{ Option string }
 
 	// OptionNeedsParam is an error reason which indicates that an option is
 	// input with no option parameter though its option configuration requires
 	// option parameters (.HasParam = true).
-	OptionNeedsParam struct{ Opt string }
+	OptionNeedsParam struct{ Option string }
 
 	// OptionTakesNoParam is an error reason which indicates that an option is
 	// input with an option parameter though its option configuration does not
 	// accept option parameters (.HasParam = false).
-	OptionTakesNoParam struct{ Opt string }
+	OptionTakesNoParam struct{ Option string }
 
 	// OptionIsNotArray is an error reason which indicates that an option is
 	// input with an option parameter multiple times though its option
 	// configuration specifies the option is not an array (.IsArray = false).
-	OptionIsNotArray struct{ Opt string }
+	OptionIsNotArray struct{ Option string }
 )
 
-const anyOpt = "*"
+const anyOption = "*"
 
 // OptCfg is a structure that represents an option configuration.
 // An option configuration consists of fields: Name, Aliases, HasParam,
@@ -126,15 +126,15 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
 	for i, cfg := range optCfgs {
 		if !cfg.HasParam {
 			if cfg.IsArray {
-				err := sabi.NewErr(ConfigIsArrayButHasNoParam{Opt: cfg.Name})
+				err := sabi.NewErr(ConfigIsArrayButHasNoParam{Option: cfg.Name})
 				return Args{cmdParams: empty}, err
 			}
 			if cfg.Default != nil {
-				err := sabi.NewErr(ConfigHasDefaultButHasNoParam{Opt: cfg.Name})
+				err := sabi.NewErr(ConfigHasDefaultButHasNoParam{Option: cfg.Name})
 				return Args{cmdParams: empty}, err
 			}
 		}
-		if cfg.Name == anyOpt {
+		if cfg.Name == anyOption {
 			hasAnyOpt = true
 			continue
 		}
@@ -163,7 +163,7 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
 		i, exists := cfgMap[opt]
 		if !exists {
 			if !hasAnyOpt {
-				return sabi.NewErr(UnconfiguredOption{Opt: opt})
+				return sabi.NewErr(UnconfiguredOption{Option: opt})
 			}
 
 			arr := optParams[opt]
@@ -177,11 +177,11 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
 		cfg := optCfgs[i]
 		if !cfg.HasParam {
 			if len(params) > 0 {
-				return sabi.NewErr(OptionTakesNoParam{Opt: cfg.Name})
+				return sabi.NewErr(OptionTakesNoParam{Option: cfg.Name})
 			}
 		} else {
 			if len(params) == 0 {
-				return sabi.NewErr(OptionNeedsParam{Opt: cfg.Name})
+				return sabi.NewErr(OptionNeedsParam{Option: cfg.Name})
 			}
 		}
 
@@ -193,7 +193,7 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
 
 		if !cfg.IsArray {
 			if len(arr) > 1 {
-				return sabi.NewErr(OptionIsNotArray{Opt: cfg.Name})
+				return sabi.NewErr(OptionIsNotArray{Option: cfg.Name})
 			}
 		}
 

--- a/parse-with_test.go
+++ b/parse-with_test.go
@@ -41,7 +41,7 @@ func testParseWith_zeroCfgAndOneLongOpt(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.UnconfiguredOption:
-		assert.Equal(t, err.Get("Opt"), "foo-bar")
+		assert.Equal(t, err.Get("Option"), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -63,7 +63,7 @@ func TestParseWith_zeroCfgAndOneShortOpt(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.UnconfiguredOption:
-		assert.Equal(t, err.Get("Opt"), "f")
+		assert.Equal(t, err.Get("Option"), "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -159,7 +159,7 @@ func TestParseWith_oneCfgAndOneDifferentLongOpt(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.UnconfiguredOption:
-		assert.Equal(t, err.Get("Opt"), "boo-far")
+		assert.Equal(t, err.Get("Option"), "boo-far")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -183,7 +183,7 @@ func TestParseWith_oneCfgAndOneDifferentShortOpt(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.UnconfiguredOption:
-		assert.Equal(t, err.Get("Opt"), "b")
+		assert.Equal(t, err.Get("Option"), "b")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -361,7 +361,7 @@ func TestParseWith_oneCfgHasParamButOneLongOptHasNoParam(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionNeedsParam:
-		assert.Equal(t, err.Get("Opt"), "foo-bar")
+		assert.Equal(t, err.Get("Option"), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -385,7 +385,7 @@ func TestParseWith_oneCfgHasParamAndOneShortOptHasNoParam(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionNeedsParam:
-		assert.Equal(t, err.Get("Opt"), "f")
+		assert.Equal(t, err.Get("Option"), "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -421,7 +421,7 @@ func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.Get("Opt"), "foo-bar")
+		assert.Equal(t, err.Get("Option"), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -451,7 +451,7 @@ func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.Get("Opt"), "foo-bar")
+		assert.Equal(t, err.Get("Option"), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -487,7 +487,7 @@ func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.Get("Opt"), "f")
+		assert.Equal(t, err.Get("Option"), "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -518,7 +518,7 @@ func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.Get("Opt"), "f")
+		assert.Equal(t, err.Get("Option"), "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -543,7 +543,7 @@ func TestParseWith_oneCfgHasNoParamButIsArray(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.ConfigIsArrayButHasNoParam:
-		assert.Equal(t, err.Get("Opt"), "foo-bar")
+		assert.Equal(t, err.Get("Option"), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -730,7 +730,7 @@ func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionIsNotArray:
-		assert.Equal(t, err.Get("Opt"), "foo-bar")
+		assert.Equal(t, err.Get("Option"), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -774,7 +774,7 @@ func TestParseWith_oneCfgHasNoParamButHasDefault(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.ConfigHasDefaultButHasNoParam:
-		assert.Equal(t, err.Get("Opt"), "foo-bar")
+		assert.Equal(t, err.Get("Option"), "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}


### PR DESCRIPTION
This PR adds a new function `ParseWith` which parses command line arguments according with option configurations.