### PR TITLE
fix: changed `.Opt` of error reasons to `.Option`

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -14,7 +14,7 @@ import (
 type /* error reason */ (
 	// OptionHasInvalidChar is an error reason which indicates that an invalid
 	// character is found in the option.
-	OptionHasInvalidChar struct{ Opt string }
+	OptionHasInvalidChar struct{ Option string }
 )
 
 var (
@@ -181,11 +181,11 @@ func parseArgs(
 						break
 					}
 					if !unicode.Is(rangeOfAlNumMarks, r) {
-						return sabi.NewErr(OptionHasInvalidChar{Opt: arg})
+						return sabi.NewErr(OptionHasInvalidChar{Option: arg})
 					}
 				} else {
 					if !unicode.Is(rangeOfAlphabets, r) {
-						return sabi.NewErr(OptionHasInvalidChar{Opt: arg})
+						return sabi.NewErr(OptionHasInvalidChar{Option: arg})
 					}
 				}
 				i++
@@ -230,7 +230,7 @@ func parseArgs(
 				}
 				opt = string(r)
 				if !unicode.Is(rangeOfAlphabets, r) {
-					return sabi.NewErr(OptionHasInvalidChar{Opt: opt})
+					return sabi.NewErr(OptionHasInvalidChar{Option: opt})
 				}
 				i++
 			}

--- a/parse_test.go
+++ b/parse_test.go
@@ -303,7 +303,7 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionHasInvalidChar:
-		assert.Equal(t, err.Get("Opt"), "abc%def")
+		assert.Equal(t, err.Get("Option"), "abc%def")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -334,7 +334,7 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionHasInvalidChar:
-		assert.Equal(t, err.Get("Opt"), "1abc")
+		assert.Equal(t, err.Get("Option"), "1abc")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -364,7 +364,7 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 
 	switch err.Reason().(type) {
 	case cliargs.OptionHasInvalidChar:
-		assert.Equal(t, err.Get("Opt"), "-aaa=123")
+		assert.Equal(t, err.Get("Option"), "-aaa=123")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -397,7 +397,7 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.OptionHasInvalidChar:
-		assert.Equal(t, err.Get("Opt"), "@")
+		assert.Equal(t, err.Get("Option"), "@")
 	default:
 		assert.Fail(t, err.Error())
 	}


### PR DESCRIPTION
In the previous PR (#2), all `.Opt` fields of error reason in `parse-with.go` were changed to `.Option`.
So this PR changes `.Opt` fields of error reasons in `parse.go` to `.Option` as well.

