### PR TITLE
new: added new functions ParseFor and MakeOptCfgsFor

### DIFF
--- a/parse-for.go
+++ b/parse-for.go
@@ -1,0 +1,493 @@
+// Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+package cliargs
+
+import (
+	"github.com/sttk-go/sabi"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type /* error reason */ (
+	// OptionStoreIsNotChangeable is an error reason which indicates that
+	// the second parameter of ParseFor function, which is set options produced
+	// by parsing command line arguments, is not a pointer.
+	OptionStoreIsNotChangeable struct{}
+
+	// FailToParseInt is an error reaason which indicates that an option
+	// parameter in command line arguments should be an integer but is invalid.
+	FailToParseInt struct {
+		Field   string
+		Input   string
+		BitSize int
+	}
+
+	// FailToParseUint is an error reason which indicates that an option
+	// parameter in command line arguments should be an unsigned integer but is
+	// invalid.
+	FailToParseUint struct {
+		Field   string
+		Input   string
+		BitSize int
+	}
+
+	// FailToParseFloat is an error reason which indicates that an option
+	// parameter in command line arguments should be a floating point number but
+	// is invalid.
+	FailToParseFloat struct {
+		Field   string
+		Input   string
+		BitSize int
+	}
+
+	// IllegalOptionType is an error reason which indicates that a type of a
+	// field of the option store is neither a boolean, a number, a string, nor
+	// an array of numbers or strings.
+	IllegalOptionType struct {
+		Field string
+		Type  reflect.Type
+	}
+)
+
+// ParseFor is a function to parse command line arguments and set their values
+// to the option store which is the second parameter of this function.
+// This function divides command line arguments to command parameters and
+// options, then stores the options to the option store, and returns the
+// command parameters.
+//
+// The configurations of options are determined by types and struct tags of
+// fields of the option store.
+// If the type is bool, the option takes no parameter.
+// If the type is integer, floating point number or string, the option can
+// takes one  option parameter, therefore it can appear once in command line
+// arguments.
+// If the type is an array, the option can takes multiple option parameters,
+// therefore it can appear multiple times in command line arguments.
+//
+// A struct tag can specify an option name, aliases, and a default value.
+// It has a special format, like `opt:foo-bar,f=123`.
+// This opt: is the struct tag key for the option configuration.
+// The string following this key and rounded by double quotes is the content
+// of the option configuration.
+// The first part of the option configuration is an option name and aliases,
+// which are separated by commas, and ends with "=" mark or end of string.
+// If the option name is empty or no struct tag, the option's name becomes same
+// with the field name of the option store.
+//
+// The string after the "=" mark is default value(s).
+// If the type of the option is a boolean, the string after "=" mark is ignored
+// because a boolean option takes no option parameter.
+// If the type of the option is a number or a string, the whole string after
+// "=" mark is a default value.
+// If the type of the option is an array, the string after "=" mark have to be
+// rounded by square brackets and separate the elements with commas, like
+// [elem1,elem2,elem3].
+// The element separator can be used other than a comma by put the separator
+// before the open square bracket, like :[elem1:elem2:elem3].
+// It's useful when some array elements include commas.
+//
+// NOTE: A default value of a string array option in a struct tag is [], like
+// `opt:"name=[]"`, it doesn't represent an array which contains only an empty
+// string but an empty array.
+// If you want to specify an array which contains only an empty string, write
+// nothing after "=" mark, like `opt:"name="`.
+//
+// Usage example:
+//
+//	type MyOptions struct {
+//	  FooBar bool     `opt:"foo-bar,f"`
+//	  Baz    int      `opt:"baz,b=99"`
+//	  Qux    string   `opt:"=XXX"`
+//	  Quux   []string `opt:"quux=[A,B,C]"`
+//	  Corge  []int
+//	}
+//	options := MyOptions{}
+//
+//	osArgs := []string{
+//	  "--foo-bar", "c1", "-b", "12", "--Qux", "ABC", "c2",
+//	  "--Corge", "20", "--Corge=21",
+//	}
+//
+//	cmdParams, err := ParseFor(osArgs, &options)
+//	cmdParams      // [c1 c2]
+//	options.FooBar // true
+//	options.Baz    // 12
+//	options.Qux    // ABC
+//	options.Quux   // [A B C]
+//	options.Corge  // [20 21]
+func ParseFor(args []string, options any) ([]string, sabi.Err) {
+	optCfgs, err := MakeOptCfgsFor(options)
+	if !err.IsOk() {
+		return empty, err
+	}
+
+	a, err := ParseWith(args, optCfgs)
+	if !err.IsOk() {
+		return empty, err
+	}
+
+	return a.cmdParams, sabi.Ok()
+}
+
+// MakeOptCfgsFor is a function to make a OptCfg array from fields of the
+// option store which is the argument of this function.
+func MakeOptCfgsFor(options any) ([]OptCfg, sabi.Err) {
+	v := reflect.ValueOf(options)
+	if v.Kind() != reflect.Ptr {
+		return nil, sabi.NewErr(OptionStoreIsNotChangeable{})
+	}
+	v = v.Elem()
+
+	t := v.Type()
+	n := t.NumField()
+
+	optCfgs := make([]OptCfg, n)
+	var err sabi.Err
+
+	for i := 0; i < n; i++ {
+		optCfgs[i], err = newOptCfg(t.Field(i))
+		if !err.IsOk() {
+			return nil, err
+		}
+		var setter func([]string) sabi.Err
+		setter, err = newValueSetter(optCfgs[i].Name, v.Field(i))
+		if !err.IsOk() {
+			return nil, err
+		}
+		optCfgs[i].OnParsed = &setter
+	}
+
+	return optCfgs, sabi.Ok()
+}
+
+func newOptCfg(fld reflect.StructField) (OptCfg, sabi.Err) {
+	opt := fld.Tag.Get("opt")
+	arr := strings.SplitN(opt, "=", 2)
+
+	names := strings.Split(arr[0], ",")
+
+	var name string
+	var aliases []string
+	if len(names) == 0 || len(names[0]) == 0 {
+		name = fld.Name
+		aliases = nil
+	} else {
+		name = names[0]
+		aliases = names[1:]
+	}
+
+	isArray := false
+	hasParam := true
+	switch fld.Type.Kind() {
+	case reflect.Slice | reflect.Array:
+		isArray = true
+	case reflect.Bool:
+		hasParam = false
+	}
+
+	var defaults []string
+	if len(arr) > 1 && hasParam {
+		def := arr[1]
+		n := len(def)
+		if !isArray {
+			defaults = []string{def}
+		} else if n > 1 && def[0] == '[' && def[n-1] == ']' {
+			defs := def[1 : n-1]
+			if len(defs) > 0 {
+				defaults = strings.Split(defs, ",")
+			} else {
+				defaults = empty
+			}
+		} else if n > 2 && def[1] == '[' && def[n-1] == ']' {
+			defs := def[2 : n-1]
+			if len(defs) > 0 {
+				defaults = strings.Split(defs, def[0:1])
+			} else {
+				defaults = empty
+			}
+		} else {
+			defaults = []string{def}
+		}
+	}
+
+	return OptCfg{
+		Name:     name,
+		Aliases:  aliases,
+		HasParam: hasParam,
+		IsArray:  isArray,
+		Default:  defaults,
+	}, sabi.Ok()
+}
+
+func newValueSetter(
+	name string,
+	fld reflect.Value,
+) (func([]string) sabi.Err, sabi.Err) {
+	t := fld.Type()
+	switch t.Kind() {
+	case reflect.Bool:
+		return newBoolSetter(name, fld)
+	case reflect.Int:
+		return newIntSetter(name, fld, strconv.IntSize)
+	case reflect.Int8:
+		return newIntSetter(name, fld, 8)
+	case reflect.Int16:
+		return newIntSetter(name, fld, 16)
+	case reflect.Int32:
+		return newIntSetter(name, fld, 32)
+	case reflect.Int64:
+		return newIntSetter(name, fld, 64)
+	case reflect.Uint:
+		return newUintSetter(name, fld, strconv.IntSize)
+	case reflect.Uint8:
+		return newUintSetter(name, fld, 8)
+	case reflect.Uint16:
+		return newUintSetter(name, fld, 16)
+	case reflect.Uint32:
+		return newUintSetter(name, fld, 32)
+	case reflect.Uint64:
+		return newUintSetter(name, fld, 64)
+	case reflect.Float32:
+		return newFloatSetter(name, fld, 32)
+	case reflect.Float64:
+		return newFloatSetter(name, fld, 64)
+	case reflect.Array | reflect.Slice:
+		elm := t.Elem()
+		switch elm.Kind() {
+		case reflect.Int:
+			return newIntArraySetter(name, fld, strconv.IntSize)
+		case reflect.Int8:
+			return newIntArraySetter(name, fld, 8)
+		case reflect.Int16:
+			return newIntArraySetter(name, fld, 16)
+		case reflect.Int32:
+			return newIntArraySetter(name, fld, 32)
+		case reflect.Int64:
+			return newIntArraySetter(name, fld, 64)
+		case reflect.Uint:
+			return newUintArraySetter(name, fld, strconv.IntSize)
+		case reflect.Uint8:
+			return newUintArraySetter(name, fld, 8)
+		case reflect.Uint16:
+			return newUintArraySetter(name, fld, 16)
+		case reflect.Uint32:
+			return newUintArraySetter(name, fld, 32)
+		case reflect.Uint64:
+			return newUintArraySetter(name, fld, 64)
+		case reflect.Float32:
+			return newFloatArraySetter(name, fld, 32)
+		case reflect.Float64:
+			return newFloatArraySetter(name, fld, 64)
+		case reflect.String:
+			return newStringArraySetter(name, fld)
+		default:
+			return newIllegalOptionTypeErr(name, t)
+		}
+	case reflect.String:
+		return newStringSetter(name, fld)
+	default:
+		return newIllegalOptionTypeErr(name, t)
+	}
+}
+
+func newIllegalOptionTypeErr(
+	name string, t reflect.Type,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func([]string) sabi.Err {
+		return sabi.Ok()
+	}
+	r := IllegalOptionType{Field: name, Type: t}
+	return fn, sabi.NewErr(r)
+}
+
+func newBoolSetter(
+	name string, fld reflect.Value,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s != nil {
+			fld.SetBool(true)
+		}
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newIntSetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if len(s) == 0 {
+			return sabi.Ok()
+		}
+		n, e := strconv.ParseInt(s[0], 0, bitSize)
+		if e != nil {
+			r := FailToParseInt{Field: name, Input: s[0], BitSize: bitSize}
+			return sabi.NewErr(r, e)
+		}
+		fld.SetInt(n)
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newUintSetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if len(s) == 0 {
+			return sabi.Ok()
+		}
+		n, e := strconv.ParseUint(s[0], 0, bitSize)
+		if e != nil {
+			r := FailToParseUint{Field: name, Input: s[0], BitSize: bitSize}
+			return sabi.NewErr(r, e)
+		}
+		fld.SetUint(n)
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newFloatSetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if len(s) == 0 {
+			return sabi.Ok()
+		}
+		n, e := strconv.ParseFloat(s[0], bitSize)
+		if e != nil {
+			r := FailToParseFloat{Field: name, Input: s[0], BitSize: bitSize}
+			return sabi.NewErr(r, e)
+		}
+		fld.SetFloat(n)
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newStringSetter(
+	name string, fld reflect.Value,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if len(s) == 0 {
+			return sabi.Ok()
+		}
+		fld.SetString(s[0])
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newIntArraySetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s == nil {
+			return sabi.Ok()
+		}
+		emp := reflect.MakeSlice(fld.Type(), 0, 0)
+		n := len(s)
+		if n == 0 {
+			fld.Set(emp)
+			return sabi.Ok()
+		}
+		t := fld.Type().Elem()
+		a := make([]reflect.Value, n)
+		for i := 0; i < n; i++ {
+			v, e := strconv.ParseInt(s[i], 0, bitSize)
+			if e != nil {
+				r := FailToParseInt{Field: name, Input: s[i], BitSize: bitSize}
+				return sabi.NewErr(r, e)
+			}
+			a[i] = reflect.ValueOf(v).Convert(t)
+		}
+		fld.Set(reflect.Append(emp, a...))
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newUintArraySetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s == nil {
+			return sabi.Ok()
+		}
+		emp := reflect.MakeSlice(fld.Type(), 0, 0)
+		n := len(s)
+		if n == 0 { // If "=[]" then n==0, else if "=" then n==1 and s[0]=""
+			fld.Set(emp)
+			return sabi.Ok()
+		}
+		t := fld.Type().Elem()
+		a := make([]reflect.Value, n)
+		for i := 0; i < n; i++ {
+			v, e := strconv.ParseUint(s[i], 0, bitSize)
+			if e != nil {
+				r := FailToParseUint{Field: name, Input: s[i], BitSize: bitSize}
+				return sabi.NewErr(r, e)
+			}
+			a[i] = reflect.ValueOf(v).Convert(t)
+		}
+		fld.Set(reflect.Append(emp, a...))
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newFloatArraySetter(
+	name string, fld reflect.Value, bitSize int,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s == nil {
+			return sabi.Ok()
+		}
+		emp := reflect.MakeSlice(fld.Type(), 0, 0)
+		n := len(s)
+		if n == 0 { // If "=[]" then n==0, else if "=" then n==1 and s[0]=""
+			fld.Set(emp)
+			return sabi.Ok()
+		}
+		t := fld.Type().Elem()
+		a := make([]reflect.Value, n)
+		for i := 0; i < n; i++ {
+			v, e := strconv.ParseFloat(s[i], bitSize)
+			if e != nil {
+				r := FailToParseFloat{Field: name, Input: s[i], BitSize: bitSize}
+				return sabi.NewErr(r, e)
+			}
+			a[i] = reflect.ValueOf(v).Convert(t)
+		}
+		fld.Set(reflect.Append(emp, a...))
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}
+
+func newStringArraySetter(
+	name string, fld reflect.Value,
+) (func([]string) sabi.Err, sabi.Err) {
+	fn := func(s []string) sabi.Err {
+		if s == nil {
+			return sabi.Ok()
+		}
+		emp := reflect.MakeSlice(fld.Type(), 0, 0)
+		n := len(s)
+		if n == 0 { // If "=[]" then n==0, else if "=" then n==1 and s[0]=""
+			fld.Set(emp)
+			return sabi.Ok()
+		}
+		a := make([]reflect.Value, n)
+		for i := 0; i < n; i++ {
+			a[i] = reflect.ValueOf(s[i])
+		}
+		fld.Set(reflect.Append(emp, a...))
+		return sabi.Ok()
+	}
+	return fn, sabi.Ok()
+}

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -1,0 +1,1399 @@
+package cliargs_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/sttk-go/cliargs"
+	"reflect"
+	"testing"
+)
+
+func TestParseFor_emptyOptionStoreAndNoArgs(t *testing.T) {
+	type MyOptions struct{}
+	args := []string{}
+	options := MyOptions{}
+	cmdParams, err := cliargs.ParseFor(args, &options)
+	assert.True(t, err.IsOk())
+	assert.Equal(t, cmdParams, []string{})
+}
+
+func TestParseFor_nonEmptyOptionStoreAndNoArgs(t *testing.T) {
+	type MyOptions struct {
+		BoolVal    bool
+		IntVal     int
+		Int8Val    int8
+		Int16Val   int16
+		Int32Val   int32
+		Int64Val   int64
+		UintVal    uint
+		Uint8Val   uint8
+		Uint16Val  uint16
+		Uint32Val  uint32
+		Uint64Val  uint64
+		Float32Val float32
+		Float64Val float64
+		StringVal  string
+		IntArr     []int
+		Int8Arr    []int8
+		Int16Arr   []int16
+		Int32Arr   []int32
+		Int64Arr   []int64
+		UintArr    []uint
+		Uint8Arr   []uint8
+		Uint16Arr  []uint16
+		Uint32Arr  []uint32
+		Uint64Arr  []uint64
+		Float32Arr []float32
+		Float64Arr []float64
+		StringArr  []string
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	cmdParams, err := cliargs.ParseFor(args, &options)
+	assert.True(t, err.IsOk())
+	assert.Equal(t, cmdParams, []string{})
+	assert.False(t, options.BoolVal)
+	assert.Equal(t, options.IntVal, 0)
+	assert.Equal(t, options.Int8Val, int8(0))
+	assert.Equal(t, options.Int16Val, int16(0))
+	assert.Equal(t, options.Int32Val, int32(0))
+	assert.Equal(t, options.Int64Val, int64(0))
+	assert.Equal(t, options.UintVal, uint(0))
+	assert.Equal(t, options.Uint8Val, uint8(0))
+	assert.Equal(t, options.Uint16Val, uint16(0))
+	assert.Equal(t, options.Uint32Val, uint32(0))
+	assert.Equal(t, options.Uint64Val, uint64(0))
+	assert.Equal(t, options.Float32Val, float32(0.0))
+	assert.Equal(t, options.Float64Val, 0.0)
+	assert.Equal(t, options.StringVal, "")
+	assert.Equal(t, options.IntArr, []int(nil))
+	assert.Equal(t, options.Int8Arr, []int8(nil))
+	assert.Equal(t, options.Int16Arr, []int16(nil))
+	assert.Equal(t, options.Int32Arr, []int32(nil))
+	assert.Equal(t, options.Int64Arr, []int64(nil))
+	assert.Equal(t, options.UintArr, []uint(nil))
+	assert.Equal(t, options.Uint8Arr, []uint8(nil))
+	assert.Equal(t, options.Uint16Arr, []uint16(nil))
+	assert.Equal(t, options.Uint32Arr, []uint32(nil))
+	assert.Equal(t, options.Uint64Arr, []uint64(nil))
+	assert.Equal(t, options.Float32Arr, []float32(nil))
+	assert.Equal(t, options.Float64Arr, []float64(nil))
+	assert.Equal(t, options.StringArr, []string(nil))
+}
+
+func TestParseFor_dontOverwriteOptionsIfNoArgs(t *testing.T) {
+	type MyOptions struct {
+		BoolVal    bool
+		IntVal     int
+		Int8Val    int8
+		Int16Val   int16
+		Int32Val   int32
+		Int64Val   int64
+		UintVal    uint
+		Uint8Val   uint8
+		Uint16Val  uint16
+		Uint32Val  uint32
+		Uint64Val  uint64
+		Float32Val float32
+		Float64Val float64
+		StringVal  string
+		IntArr     []int
+		Int8Arr    []int8
+		Int16Arr   []int16
+		Int32Arr   []int32
+		Int64Arr   []int64
+		UintArr    []uint
+		Uint8Arr   []uint8
+		Uint16Arr  []uint16
+		Uint32Arr  []uint32
+		Uint64Arr  []uint64
+		Float32Arr []float32
+		Float64Arr []float64
+		StringArr  []string
+	}
+	options := MyOptions{
+		BoolVal:    true,
+		IntVal:     111,
+		Int8Val:    22,
+		Int16Val:   333,
+		Int32Val:   444,
+		Int64Val:   555,
+		UintVal:    666,
+		Uint8Val:   77,
+		Uint16Val:  888,
+		Uint32Val:  999,
+		Uint64Val:  1111,
+		Float32Val: 0.123,
+		Float64Val: 0.456789,
+		StringVal:  "abcdefg",
+		IntArr:     []int{1, 1, 1},
+		Int8Arr:    []int8{2, 2},
+		Int16Arr:   []int16{3, 3, 3},
+		Int32Arr:   []int32{4, 4, 4},
+		Int64Arr:   []int64{5, 5, 5},
+		UintArr:    []uint{6, 6, 6},
+		Uint8Arr:   []uint8{7, 7},
+		Uint16Arr:  []uint16{8, 8, 8},
+		Uint32Arr:  []uint32{9, 9, 9},
+		Uint64Arr:  []uint64{1, 1, 1, 1},
+		Float32Arr: []float32{0.1, 2.3},
+		Float64Arr: []float64{0.45, 6.789},
+		StringArr:  []string{"ab", "cd", "efg"},
+	}
+
+	args := []string{}
+	cmdParams, err := cliargs.ParseFor(args, &options)
+	assert.True(t, err.IsOk())
+	assert.Equal(t, cmdParams, []string{})
+	assert.True(t, options.BoolVal)
+	assert.Equal(t, options.IntVal, 111)
+	assert.Equal(t, options.Int8Val, int8(22))
+	assert.Equal(t, options.Int16Val, int16(333))
+	assert.Equal(t, options.Int32Val, int32(444))
+	assert.Equal(t, options.Int64Val, int64(555))
+	assert.Equal(t, options.UintVal, uint(666))
+	assert.Equal(t, options.Uint8Val, uint8(77))
+	assert.Equal(t, options.Uint16Val, uint16(888))
+	assert.Equal(t, options.Uint32Val, uint32(999))
+	assert.Equal(t, options.Uint64Val, uint64(1111))
+	assert.Equal(t, options.Float32Val, float32(0.123))
+	assert.Equal(t, options.Float64Val, 0.456789)
+	assert.Equal(t, options.StringVal, "abcdefg")
+	assert.Equal(t, options.IntArr, []int{1, 1, 1})
+	assert.Equal(t, options.Int8Arr, []int8{2, 2})
+	assert.Equal(t, options.Int16Arr, []int16{3, 3, 3})
+	assert.Equal(t, options.Int32Arr, []int32{4, 4, 4})
+	assert.Equal(t, options.Int64Arr, []int64{5, 5, 5})
+	assert.Equal(t, options.UintArr, []uint{6, 6, 6})
+	assert.Equal(t, options.Uint8Arr, []uint8{7, 7})
+	assert.Equal(t, options.Uint16Arr, []uint16{8, 8, 8})
+	assert.Equal(t, options.Uint32Arr, []uint32{9, 9, 9})
+	assert.Equal(t, options.Uint64Arr, []uint64{1, 1, 1, 1})
+	assert.Equal(t, options.Float32Arr, []float32{0.1, 2.3})
+	assert.Equal(t, options.Float64Arr, []float64{0.45, 6.789})
+	assert.Equal(t, options.StringArr, []string{"ab", "cd", "efg"})
+}
+
+func TestParseFor_optionIsBoolAndArgIsName(t *testing.T) {
+	type MyOptions struct {
+		Flag bool `opt:"flag,f"`
+	}
+	options := MyOptions{}
+
+	args := []string{"--flag", "abc"}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.True(t, options.Flag)
+}
+
+func TestParseFor_optionIsBoolAndArgIsAlias(t *testing.T) {
+	type MyOptions struct {
+		Flag bool `opt:"flag,f"`
+	}
+	options := MyOptions{}
+
+	args := []string{"-f", "abc"}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.True(t, options.Flag)
+}
+
+func TestParseFor_optionsAreIntAndArgsAreNames(t *testing.T) {
+	type MyOptions struct {
+		IntVal   int   `opt:"int-val,i"`
+		Int8Val  int8  `opt:"int8-val,j"`
+		Int16Val int16 `opt:"int16-val,k"`
+		Int32Val int32 `opt:"int32-val,m"`
+		Int64Val int64 `opt:"int64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--int-val", "1",
+		"--int8-val", "2",
+		"--int16-val", "3",
+		"--int32-val", "4",
+		"--int64-val", "5",
+		"abc",
+	}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.IntVal, 1)
+	assert.Equal(t, options.Int8Val, int8(2))
+	assert.Equal(t, options.Int16Val, int16(3))
+	assert.Equal(t, options.Int32Val, int32(4))
+	assert.Equal(t, options.Int64Val, int64(5))
+}
+
+func TestParseFor_optionsAreIntAndArgsAreAliases(t *testing.T) {
+	type MyOptions struct {
+		IntVal   int   `opt:"int-val,i"`
+		Int8Val  int8  `opt:"int8-val,j"`
+		Int16Val int16 `opt:"int16-val,k"`
+		Int32Val int32 `opt:"int32-val,m"`
+		Int64Val int64 `opt:"int64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"-i", "1",
+		"-j", "2",
+		"-k", "3",
+		"-m", "4",
+		"-n", "5",
+		"abc",
+	}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.IntVal, 1)
+	assert.Equal(t, options.Int8Val, int8(2))
+	assert.Equal(t, options.Int16Val, int16(3))
+	assert.Equal(t, options.Int32Val, int32(4))
+	assert.Equal(t, options.Int64Val, int64(5))
+}
+
+func TestParseFor_optionsAreUintAndArgsAreNames(t *testing.T) {
+	type MyOptions struct {
+		UintVal   uint   `opt:"uint-val,i"`
+		Uint8Val  uint8  `opt:"uint8-val,j"`
+		Uint16Val uint16 `opt:"uint16-val,k"`
+		Uint32Val uint32 `opt:"uint32-val,m"`
+		Uint64Val uint64 `opt:"uint64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--uint-val", "1",
+		"--uint8-val", "2",
+		"--uint16-val", "3",
+		"--uint32-val", "4",
+		"--uint64-val", "5",
+		"abc",
+	}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.UintVal, uint(1))
+	assert.Equal(t, options.Uint8Val, uint8(2))
+	assert.Equal(t, options.Uint16Val, uint16(3))
+	assert.Equal(t, options.Uint32Val, uint32(4))
+	assert.Equal(t, options.Uint64Val, uint64(5))
+}
+
+func TestParseFor_optionsAreUintAndArgsAreAliases(t *testing.T) {
+	type MyOptions struct {
+		UintVal   uint   `opt:"uint-val,i"`
+		Uint8Val  uint8  `opt:"uint8-val,j"`
+		Uint16Val uint16 `opt:"uint16-val,k"`
+		Uint32Val uint32 `opt:"uint32-val,m"`
+		Uint64Val uint64 `opt:"uint64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"-i", "1",
+		"-j", "2",
+		"-k", "3",
+		"-m", "4",
+		"-n", "5",
+		"abc",
+	}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.UintVal, uint(1))
+	assert.Equal(t, options.Uint8Val, uint8(2))
+	assert.Equal(t, options.Uint16Val, uint16(3))
+	assert.Equal(t, options.Uint32Val, uint32(4))
+	assert.Equal(t, options.Uint64Val, uint64(5))
+}
+
+func TestParseFor_optionsAreFloatAndArgsAreNames(t *testing.T) {
+	type MyOptions struct {
+		Float32Val float32 `opt:"float32-val,m"`
+		Float64Val float64 `opt:"float64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--float32-val", "0.1234",
+		"--float64-val", "0.5678",
+		"abc",
+	}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.Float32Val, float32(0.1234))
+	assert.Equal(t, options.Float64Val, 0.5678)
+}
+
+func TestParseFor_optionsAreFloatAndArgsAreAliases(t *testing.T) {
+	type MyOptions struct {
+		Float32Val float32 `opt:"float32-val,m"`
+		Float64Val float64 `opt:"float64-val,n"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"-m", "0.1234",
+		"-n", "0.5678",
+		"abc",
+	}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.Float32Val, float32(0.1234))
+	assert.Equal(t, options.Float64Val, 0.5678)
+}
+
+func TestParseFor_optionsAreStringAndArgsAreNames(t *testing.T) {
+	type MyOptions struct {
+		StringVal string `opt:"string-val,s"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--string-val", "def",
+		"abc",
+	}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.StringVal, "def")
+}
+
+func TestParseFor_optionsAreStringAndArgsAreAliases(t *testing.T) {
+	type MyOptions struct {
+		StringVal string `opt:"string-val,s"`
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"-s", "def",
+		"abc",
+	}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, options.StringVal, "def")
+}
+
+func TestParseFor_defaultValueIsInt(t *testing.T) {
+	type MyOptions struct {
+		IntVal   int   `opt:"=11"`
+		Int8Val  int8  `opt:"=22"`
+		Int16Val int16 `opt:"=33"`
+		Int32Val int32 `opt:"=44"`
+		Int64Val int64 `opt:"=55"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntVal, 11)
+	assert.Equal(t, options.Int8Val, int8(22))
+	assert.Equal(t, options.Int16Val, int16(33))
+	assert.Equal(t, options.Int32Val, int32(44))
+	assert.Equal(t, options.Int64Val, int64(55))
+}
+
+func TestParseFor_defaultValueIsNegativeInt(t *testing.T) {
+	type MyOptions struct {
+		IntVal   int   `opt:"=-11"`
+		Int8Val  int8  `opt:"=-22"`
+		Int16Val int16 `opt:"=-33"`
+		Int32Val int32 `opt:"=-44"`
+		Int64Val int64 `opt:"=-55"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntVal, -11)
+	assert.Equal(t, options.Int8Val, int8(-22))
+	assert.Equal(t, options.Int16Val, int16(-33))
+	assert.Equal(t, options.Int32Val, int32(-44))
+	assert.Equal(t, options.Int64Val, int64(-55))
+}
+
+func TestParseFor_defaultValueIsUint(t *testing.T) {
+	type MyOptions struct {
+		UintVal   uint   `opt:"=11"`
+		Uint8Val  uint8  `opt:"=22"`
+		Uint16Val uint16 `opt:"=33"`
+		Uint32Val uint32 `opt:"=44"`
+		Uint64Val uint64 `opt:"=55"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintVal, uint(11))
+	assert.Equal(t, options.Uint8Val, uint8(22))
+	assert.Equal(t, options.Uint16Val, uint16(33))
+	assert.Equal(t, options.Uint32Val, uint32(44))
+	assert.Equal(t, options.Uint64Val, uint64(55))
+}
+
+func TestParseFor_defaultValueIsFloat(t *testing.T) {
+	type MyOptions struct {
+		Float32Val float32 `opt:"=0.123"`
+		Float64Val float64 `opt:"=0.456789"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Val, float32(0.123))
+	assert.Equal(t, options.Float64Val, float64(0.456789))
+}
+
+func TestParseFor_defaultValueIsNegativeFloat(t *testing.T) {
+	type MyOptions struct {
+		Float32Val float32 `opt:"=-0.123"`
+		Float64Val float64 `opt:"=-0.456789"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Val, float32(-0.123))
+	assert.Equal(t, options.Float64Val, float64(-0.456789))
+}
+
+func TestParseFor_defaultValueIsIntArrayAndSize0(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[]"`
+		Int8Arr  []int8  `opt:"=[]"`
+		Int16Arr []int16 `opt:"=[]"`
+		Int32Arr []int32 `opt:"=[]"`
+		Int64Arr []int64 `opt:"=[]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{})
+	assert.Equal(t, options.Int8Arr, []int8{})
+	assert.Equal(t, options.Int16Arr, []int16{})
+	assert.Equal(t, options.Int32Arr, []int32{})
+	assert.Equal(t, options.Int64Arr, []int64{})
+}
+
+func TestParseFor_overwriteIntArrayWithDefaultValueIfSize0(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[]"`
+		Int8Arr  []int8  `opt:"=[]"`
+		Int16Arr []int16 `opt:"=[]"`
+		Int32Arr []int32 `opt:"=[]"`
+		Int64Arr []int64 `opt:"=[]"`
+	}
+	options := MyOptions{
+		IntArr:   []int{1},
+		Int8Arr:  []int8{2},
+		Int16Arr: []int16{3},
+		Int32Arr: []int32{4},
+		Int64Arr: []int64{5},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{})
+	assert.Equal(t, options.Int8Arr, []int8{})
+	assert.Equal(t, options.Int16Arr, []int16{})
+	assert.Equal(t, options.Int32Arr, []int32{})
+	assert.Equal(t, options.Int64Arr, []int64{})
+}
+
+func TestParseFor_defaultValueIsIntArrayAndSize1(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[1]"`
+		Int8Arr  []int8  `opt:"=[2]"`
+		Int16Arr []int16 `opt:"=[3]"`
+		Int32Arr []int32 `opt:"=[4]"`
+		Int64Arr []int64 `opt:"=[5]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{1})
+	assert.Equal(t, options.Int8Arr, []int8{2})
+	assert.Equal(t, options.Int16Arr, []int16{3})
+	assert.Equal(t, options.Int32Arr, []int32{4})
+	assert.Equal(t, options.Int64Arr, []int64{5})
+}
+
+func TestParseFor_overwriteIntArrayWithDefaultValueIfSize1(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[1]"`
+		Int8Arr  []int8  `opt:"=[2]"`
+		Int16Arr []int16 `opt:"=[3]"`
+		Int32Arr []int32 `opt:"=[4]"`
+		Int64Arr []int64 `opt:"=[5]"`
+	}
+	options := MyOptions{
+		IntArr:   []int{11},
+		Int8Arr:  []int8{22},
+		Int16Arr: []int16{33},
+		Int32Arr: []int32{44},
+		Int64Arr: []int64{55},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{1})
+	assert.Equal(t, options.Int8Arr, []int8{2})
+	assert.Equal(t, options.Int16Arr, []int16{3})
+	assert.Equal(t, options.Int32Arr, []int32{4})
+	assert.Equal(t, options.Int64Arr, []int64{5})
+}
+
+func TestParseFor_defaultValueIsIntArrayAndSize2(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[1,2]"`
+		Int8Arr  []int8  `opt:"=[2,3]"`
+		Int16Arr []int16 `opt:"=[3,4]"`
+		Int32Arr []int32 `opt:"=[4,5]"`
+		Int64Arr []int64 `opt:"=[5,6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{1, 2})
+	assert.Equal(t, options.Int8Arr, []int8{2, 3})
+	assert.Equal(t, options.Int16Arr, []int16{3, 4})
+	assert.Equal(t, options.Int32Arr, []int32{4, 5})
+	assert.Equal(t, options.Int64Arr, []int64{5, 6})
+}
+
+func TestParseFor_overwriteIntArrayWithDefaultValueIfSize2(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[1,2]"`
+		Int8Arr  []int8  `opt:"=[2,3]"`
+		Int16Arr []int16 `opt:"=[3,4]"`
+		Int32Arr []int32 `opt:"=[4,5]"`
+		Int64Arr []int64 `opt:"=[5,6]"`
+	}
+	options := MyOptions{
+		IntArr:   []int{11},
+		Int8Arr:  []int8{22},
+		Int16Arr: []int16{33},
+		Int32Arr: []int32{44},
+		Int64Arr: []int64{55},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{1, 2})
+	assert.Equal(t, options.Int8Arr, []int8{2, 3})
+	assert.Equal(t, options.Int16Arr, []int16{3, 4})
+	assert.Equal(t, options.Int32Arr, []int32{4, 5})
+	assert.Equal(t, options.Int64Arr, []int64{5, 6})
+}
+
+func TestParseFor_defaultValueIsNegativeIntArray(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=[-1,-2]"`
+		Int8Arr  []int8  `opt:"=[-2,-3]"`
+		Int16Arr []int16 `opt:"=[-3,-4]"`
+		Int32Arr []int32 `opt:"=[-4,-5]"`
+		Int64Arr []int64 `opt:"=[-5,-6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{-1, -2})
+	assert.Equal(t, options.Int8Arr, []int8{-2, -3})
+	assert.Equal(t, options.Int16Arr, []int16{-3, -4})
+	assert.Equal(t, options.Int32Arr, []int32{-4, -5})
+	assert.Equal(t, options.Int64Arr, []int64{-5, -6})
+}
+
+func TestParseFor_defaultValueIsIntArraySeparatedByColons(t *testing.T) {
+	type MyOptions struct {
+		IntArr   []int   `opt:"=:[-1:-2]"`
+		Int8Arr  []int8  `opt:"=/[-2/-3]"`
+		Int16Arr []int16 `opt:"=![-3!-4]"`
+		Int32Arr []int32 `opt:"=|[-4|-5]"`
+		Int64Arr []int64 `opt:"='[-5'-6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.IntArr, []int{-1, -2})
+	assert.Equal(t, options.Int8Arr, []int8{-2, -3})
+	assert.Equal(t, options.Int16Arr, []int16{-3, -4})
+	assert.Equal(t, options.Int32Arr, []int32{-4, -5})
+	assert.Equal(t, options.Int64Arr, []int64{-5, -6})
+}
+
+func TestParseFor_defaultValueIsUintArrayAndSize0(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[]"`
+		Uint8Arr  []uint8  `opt:"=[]"`
+		Uint16Arr []uint16 `opt:"=[]"`
+		Uint32Arr []uint32 `opt:"=[]"`
+		Uint64Arr []uint64 `opt:"=[]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{})
+	assert.Equal(t, options.Uint8Arr, []uint8{})
+	assert.Equal(t, options.Uint16Arr, []uint16{})
+	assert.Equal(t, options.Uint32Arr, []uint32{})
+	assert.Equal(t, options.Uint64Arr, []uint64{})
+}
+
+func TestParseFor_overwriteUintArrayWithDefaultValueIfSize0(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[]"`
+		Uint8Arr  []uint8  `opt:"=[]"`
+		Uint16Arr []uint16 `opt:"=[]"`
+		Uint32Arr []uint32 `opt:"=[]"`
+		Uint64Arr []uint64 `opt:"=[]"`
+	}
+	options := MyOptions{
+		UintArr:   []uint{1},
+		Uint8Arr:  []uint8{2},
+		Uint16Arr: []uint16{3},
+		Uint32Arr: []uint32{4},
+		Uint64Arr: []uint64{5},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{})
+	assert.Equal(t, options.Uint8Arr, []uint8{})
+	assert.Equal(t, options.Uint16Arr, []uint16{})
+	assert.Equal(t, options.Uint32Arr, []uint32{})
+	assert.Equal(t, options.Uint64Arr, []uint64{})
+}
+
+func TestParseFor_defaultValueIsUintArrayAndSize1(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[1]"`
+		Uint8Arr  []uint8  `opt:"=[2]"`
+		Uint16Arr []uint16 `opt:"=[3]"`
+		Uint32Arr []uint32 `opt:"=[4]"`
+		Uint64Arr []uint64 `opt:"=[5]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1})
+	assert.Equal(t, options.Uint8Arr, []uint8{2})
+	assert.Equal(t, options.Uint16Arr, []uint16{3})
+	assert.Equal(t, options.Uint32Arr, []uint32{4})
+	assert.Equal(t, options.Uint64Arr, []uint64{5})
+}
+
+func TestParseFor_overwriteUintArrayWithDefaultValueIfSize1(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[1]"`
+		Uint8Arr  []uint8  `opt:"=[2]"`
+		Uint16Arr []uint16 `opt:"=[3]"`
+		Uint32Arr []uint32 `opt:"=[4]"`
+		Uint64Arr []uint64 `opt:"=[5]"`
+	}
+	options := MyOptions{
+		UintArr:   []uint{11},
+		Uint8Arr:  []uint8{22},
+		Uint16Arr: []uint16{33},
+		Uint32Arr: []uint32{44},
+		Uint64Arr: []uint64{55},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1})
+	assert.Equal(t, options.Uint8Arr, []uint8{2})
+	assert.Equal(t, options.Uint16Arr, []uint16{3})
+	assert.Equal(t, options.Uint32Arr, []uint32{4})
+	assert.Equal(t, options.Uint64Arr, []uint64{5})
+}
+
+func TestParseFor_defaultValueIsUintArrayAndSize2(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[1,2]"`
+		Uint8Arr  []uint8  `opt:"=[2,3]"`
+		Uint16Arr []uint16 `opt:"=[3,4]"`
+		Uint32Arr []uint32 `opt:"=[4,5]"`
+		Uint64Arr []uint64 `opt:"=[5,6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1, 2})
+	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
+	assert.Equal(t, options.Uint16Arr, []uint16{3, 4})
+	assert.Equal(t, options.Uint32Arr, []uint32{4, 5})
+	assert.Equal(t, options.Uint64Arr, []uint64{5, 6})
+}
+
+func TestParseFor_overwriteUintArrayWithDefaultValueIfSize2(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=[1,2]"`
+		Uint8Arr  []uint8  `opt:"=[2,3]"`
+		Uint16Arr []uint16 `opt:"=[3,4]"`
+		Uint32Arr []uint32 `opt:"=[4,5]"`
+		Uint64Arr []uint64 `opt:"=[5,6]"`
+	}
+	options := MyOptions{
+		UintArr:   []uint{11},
+		Uint8Arr:  []uint8{22},
+		Uint16Arr: []uint16{33},
+		Uint32Arr: []uint32{44},
+		Uint64Arr: []uint64{55},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1, 2})
+	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
+	assert.Equal(t, options.Uint16Arr, []uint16{3, 4})
+	assert.Equal(t, options.Uint32Arr, []uint32{4, 5})
+	assert.Equal(t, options.Uint64Arr, []uint64{5, 6})
+}
+
+func TestParseFor_defaultValueIsUintArraySeparatedByColons(t *testing.T) {
+	type MyOptions struct {
+		UintArr   []uint   `opt:"=:[1:2]"`
+		Uint8Arr  []uint8  `opt:"=/[2/3]"`
+		Uint16Arr []uint16 `opt:"=![3!4]"`
+		Uint32Arr []uint32 `opt:"=|[4|5]"`
+		Uint64Arr []uint64 `opt:"='[5'6]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.UintArr, []uint{1, 2})
+	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
+	assert.Equal(t, options.Uint16Arr, []uint16{3, 4})
+	assert.Equal(t, options.Uint32Arr, []uint32{4, 5})
+	assert.Equal(t, options.Uint64Arr, []uint64{5, 6})
+}
+
+func TestParseFor_defaultValueIsFloatArrayAndSize0(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[]"`
+		Float64Arr []float64 `opt:"=[]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{})
+	assert.Equal(t, options.Float64Arr, []float64{})
+}
+
+func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize0(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[]"`
+		Float64Arr []float64 `opt:"=[]"`
+	}
+	options := MyOptions{
+		Float32Arr: []float32{0.999},
+		Float64Arr: []float64{0.888},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{})
+	assert.Equal(t, options.Float64Arr, []float64{})
+}
+
+func TestParseFor_defaultValueIsFloatArrayAndSize1(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[0.1]"`
+		Float64Arr []float64 `opt:"=[0.2]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{0.1})
+	assert.Equal(t, options.Float64Arr, []float64{0.2})
+}
+
+func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize1(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[0.1]"`
+		Float64Arr []float64 `opt:"=[0.2]"`
+	}
+	options := MyOptions{
+		Float32Arr: []float32{0.99},
+		Float64Arr: []float64{0.88},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{0.1})
+	assert.Equal(t, options.Float64Arr, []float64{0.2})
+}
+
+func TestParseFor_defaultValueIsFloatArrayAndSize2(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[0.1,0.2]"`
+		Float64Arr []float64 `opt:"=[0.3,0.4]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
+	assert.Equal(t, options.Float64Arr, []float64{0.3, 0.4})
+}
+
+func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize2(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[0.1,0.2]"`
+		Float64Arr []float64 `opt:"=[0.3,0.4]"`
+	}
+	options := MyOptions{
+		Float32Arr: []float32{0.99},
+		Float64Arr: []float64{0.88},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
+	assert.Equal(t, options.Float64Arr, []float64{0.3, 0.4})
+}
+
+func TestParseFor_defaultValueIsNegativeFloatArray(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=[-0.1,-0.2]"`
+		Float64Arr []float64 `opt:"=[-0.3,-0.4]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
+	assert.Equal(t, options.Float64Arr, []float64{-0.3, -0.4})
+}
+
+func TestParseFor_defaultValueIsFloatArraySeparatedByColons(t *testing.T) {
+	type MyOptions struct {
+		Float32Arr []float32 `opt:"=|[-0.1|-0.2]"`
+		Float64Arr []float64 `opt:"='[-0.3'-0.4]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
+	assert.Equal(t, options.Float64Arr, []float64{-0.3, -0.4})
+}
+
+func TestParseFor_defaultValueIsStringAndSize0(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{})
+}
+
+func TestParseFor_overwriteStringArrayWithDefaultValueIfSize0(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[]"`
+	}
+	options := MyOptions{
+		StringArr: []string{"ZZZ"},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{})
+}
+
+func TestParseFor_defaultValueIsStringArrayAndSize1(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[ABC]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC"})
+}
+
+func TestParseFor_overwriteStringArrayWithDefaultValueIfSize1(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[ABC]"`
+	}
+	options := MyOptions{
+		StringArr: []string{"ZZZ"},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC"})
+}
+
+func TestParseFor_defaultValueIsStringArrayAndSize2(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[ABC,DEF]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
+}
+
+func TestParseFor_overwriteStringArrayWithDefaultValueIfSize2(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=[ABC,DEF]"`
+	}
+	options := MyOptions{
+		StringArr: []string{"ZZZ"},
+	}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
+}
+
+func TestParseFor_defaultValueIsStringArraySeparatedByColons(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"=|[ABC|DEF]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
+}
+
+func TestParseFor_ignoreEmptyDefaultValueIfOptionIsBool(t *testing.T) {
+	type MyOptions struct {
+		BoolVar bool `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.False(t, options.BoolVar)
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
+	type MyOptions struct {
+		IntVar int `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case cliargs.FailToParseInt:
+		assert.Equal(t, err.Get("Field"), "IntVar")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
+	type MyOptions struct {
+		UintVar uint `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case cliargs.FailToParseUint:
+		assert.Equal(t, err.Get("Field"), "UintVar")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
+	type MyOptions struct {
+		Float64Var float64 `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case cliargs.FailToParseFloat:
+		assert.Equal(t, err.Get("Field"), "Float64Var")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsString(t *testing.T) {
+	type MyOptions struct {
+		StringVar string `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringVar, "")
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
+	type MyOptions struct {
+		IntArr []int `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case cliargs.FailToParseInt:
+		assert.Equal(t, err.Get("Field"), "IntArr")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
+	type MyOptions struct {
+		UintArr []uint `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case cliargs.FailToParseUint:
+		assert.Equal(t, err.Get("Field"), "UintArr")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_errorEmptyDefaultValueIfOptionIsFloatArray(t *testing.T) {
+	type MyOptions struct {
+		Float64Arr []float64 `opt:"="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case cliargs.FailToParseFloat:
+		assert.Equal(t, err.Get("Field"), "Float64Arr")
+		assert.Equal(t, err.Get("Input"), "")
+		assert.Equal(t, err.Get("BitSize"), 64)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_optionIsStringArrayAndSetOneEmptyStringByDefaultArray(t *testing.T) {
+	type MyOptions struct {
+		StringArr []string `opt:"str-arr="`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.Equal(t, options.StringArr, []string{""})
+}
+
+func TestParseFor_defaultValueIsIgnoreWhenTypeIsBool(t *testing.T) {
+	type MyOptions struct {
+		BoolVar bool `opt:"bool-var=true"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, params, []string{})
+	assert.False(t, options.BoolVar)
+}
+
+func TestParseFor_errorIfDefaultValueIsInvalidType(t *testing.T) {
+	type MyOptions struct {
+		BoolArr []bool
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	params, err := cliargs.ParseFor(args, &options)
+
+	assert.Equal(t, params, []string{})
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case cliargs.IllegalOptionType:
+		assert.Equal(t, err.Get("Field"), "BoolArr")
+		assert.Equal(t, err.Get("Type"), reflect.TypeOf(options.BoolArr))
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestParseFor_multipleOptsAndMultipleArgs(t *testing.T) {
+	type MyOptions struct {
+		FooBar bool     `opt:"foo-bar,f"`
+		Baz    int      `opt:"baz,b=99"`
+		Qux    string   `opt:"=XXX"`
+		Quux   []string `opt:"quux=/[A/B/C]"`
+		Corge  []int
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--foo-bar", "c1", "-b", "12", "--Qux", "ABC", "c2",
+		"--Corge", "20", "--Corge=21",
+	}
+
+	cmdParams, err := cliargs.ParseFor(args, &options)
+
+	assert.True(t, err.IsOk())
+	assert.Equal(t, cmdParams, []string{"c1", "c2"})
+	assert.True(t, options.FooBar)
+	assert.Equal(t, options.Baz, 12)
+	assert.Equal(t, options.Qux, "ABC")
+	assert.Equal(t, options.Quux, []string{"A", "B", "C"})
+	assert.Equal(t, options.Corge, []int{20, 21})
+}
+
+func TestMakeOptCfgsFor_multipleOptsAndMultipleArgs(t *testing.T) {
+	type MyOptions struct {
+		FooBar bool     `opt:"foo-bar,f"`
+		Baz    int      `opt:"baz,b=99"`
+		Qux    string   `opt:"=XXX"`
+		Quux   []string `opt:"quux=/[A/B/C]"`
+		Corge  []int
+	}
+	options := MyOptions{}
+
+	args := []string{
+		"--foo-bar", "c1", "-b", "12", "--Qux", "ABC", "c2",
+		"--Corge", "20", "--Corge=21",
+	}
+
+	optCfgs, err0 := cliargs.MakeOptCfgsFor(&options)
+	assert.True(t, err0.IsOk())
+	assert.Equal(t, optCfgs[0].Name, "foo-bar")
+	assert.Equal(t, optCfgs[0].Aliases, []string{"f"})
+	assert.False(t, optCfgs[0].HasParam)
+	assert.False(t, optCfgs[0].IsArray)
+	assert.Nil(t, optCfgs[0].Default)
+	assert.NotNil(t, optCfgs[0].OnParsed)
+	assert.Equal(t, optCfgs[1].Name, "baz")
+	assert.Equal(t, optCfgs[1].Aliases, []string{"b"})
+	assert.True(t, optCfgs[1].HasParam)
+	assert.False(t, optCfgs[1].IsArray)
+	assert.Equal(t, optCfgs[1].Default, []string{"99"})
+	assert.NotNil(t, optCfgs[1].OnParsed)
+	assert.Equal(t, optCfgs[2].Name, "Qux")
+	assert.Equal(t, optCfgs[2].Aliases, []string(nil))
+	assert.True(t, optCfgs[2].HasParam)
+	assert.False(t, optCfgs[2].IsArray)
+	assert.Equal(t, optCfgs[2].Default, []string{"XXX"})
+	assert.NotNil(t, optCfgs[2].OnParsed)
+	assert.Equal(t, optCfgs[3].Name, "quux")
+	assert.Equal(t, optCfgs[3].Aliases, []string{})
+	assert.True(t, optCfgs[3].HasParam)
+	assert.True(t, optCfgs[3].IsArray)
+	assert.Equal(t, optCfgs[3].Default, []string{"A", "B", "C"})
+	assert.NotNil(t, optCfgs[3].OnParsed)
+	assert.Equal(t, optCfgs[4].Name, "Corge")
+	assert.Equal(t, optCfgs[4].Aliases, []string(nil))
+	assert.True(t, optCfgs[4].HasParam)
+	assert.True(t, optCfgs[4].IsArray)
+	assert.Equal(t, optCfgs[4].Default, []string(nil))
+	assert.NotNil(t, optCfgs[4].OnParsed)
+
+	a, err1 := cliargs.ParseWith(args, optCfgs)
+	assert.True(t, err1.IsOk())
+	assert.Equal(t, a.CmdParams(), []string{"c1", "c2"})
+	assert.True(t, a.HasOpt("foo-bar"))
+	assert.True(t, a.HasOpt("baz"))
+	assert.True(t, a.HasOpt("Qux"))
+	assert.True(t, a.HasOpt("quux"))
+	assert.True(t, a.HasOpt("Corge"))
+	assert.Equal(t, a.OptParam("foo-bar"), "")
+	assert.Equal(t, a.OptParam("baz"), "12")
+	assert.Equal(t, a.OptParam("Qux"), "ABC")
+	assert.Equal(t, a.OptParam("quux"), "A")
+	assert.Equal(t, a.OptParam("Corge"), "20")
+	assert.Equal(t, a.OptParams("foo-bar"), []string{})
+	assert.Equal(t, a.OptParams("baz"), []string{"12"})
+	assert.Equal(t, a.OptParams("Qux"), []string{"ABC"})
+	assert.Equal(t, a.OptParams("quux"), []string{"A", "B", "C"})
+	assert.Equal(t, a.OptParams("Corge"), []string{"20", "21"})
+	assert.True(t, options.FooBar)
+	assert.Equal(t, options.Baz, 12)
+	assert.Equal(t, options.Qux, "ABC")
+	assert.Equal(t, options.Quux, []string{"A", "B", "C"})
+	assert.Equal(t, options.Corge, []int{20, 21})
+}


### PR DESCRIPTION
This PR adds `ParseFor` function which is a function which receives an option store as the second parameter, parses command line arguments according with the option store's field types and struct tags, and set the results to the option store's fields.

In addition, this PR adds `MakeOptCfgsFor` function which makes a `OptCfg` array from an option store specified as argument.