### PR TITLE
new: added runeBuffer

### DIFF
--- a/rune-buffer.go
+++ b/rune-buffer.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+package cliargs
+
+type runeBuffer struct {
+	runes  []rune
+	length int
+}
+
+func newRuneBuffer(capacity int) runeBuffer {
+	return runeBuffer{runes: make([]rune, capacity)}
+}
+
+func (rb *runeBuffer) add(runes ...rune) bool {
+	n := len(runes)
+	if rb.length+n > len(rb.runes) {
+		return false
+	}
+	for i, r := range runes {
+		rb.runes[rb.length+i] = r
+	}
+	rb.length += n
+	return true
+}
+
+func (rb *runeBuffer) cr(start int) {
+	if start < 0 {
+		return
+	}
+	if start >= rb.length {
+		rb.length = 0
+		return
+	}
+
+	n := rb.length - start
+	for i := 0; i < n; i++ {
+		rb.runes[i] = rb.runes[i+start]
+	}
+	rb.length = n
+}
+
+func (rb runeBuffer) slice() []rune {
+	return rb.runes[0:rb.length]
+}

--- a/rune-buffer_test.go
+++ b/rune-buffer_test.go
@@ -1,0 +1,119 @@
+package cliargs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewRuneBuffer_empty(t *testing.T) {
+	rb := newRuneBuffer(0)
+	assert.Equal(t, rb.runes, []rune{})
+	assert.Equal(t, rb.length, 0)
+	assert.Equal(t, len(rb.runes), 0)
+	assert.Equal(t, cap(rb.runes), 0)
+	assert.Equal(t, rb.slice(), []rune{})
+}
+
+func TestRuneBuffer_add(t *testing.T) {
+	rb := newRuneBuffer(5)
+	assert.Equal(t, rb.runes, []rune{0, 0, 0, 0, 0})
+	assert.Equal(t, rb.length, 0)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{})
+
+	assert.True(t, rb.add('1'))
+	assert.Equal(t, rb.runes, []rune{'1', 0, 0, 0, 0})
+	assert.Equal(t, rb.length, 1)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'1'})
+
+	assert.True(t, rb.add('2', '3'))
+	assert.Equal(t, rb.runes, []rune{'1', '2', '3', 0, 0})
+	assert.Equal(t, rb.length, 3)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'1', '2', '3'})
+
+	assert.False(t, rb.add('x', 'y', 'z'))
+	assert.Equal(t, rb.runes, []rune{'1', '2', '3', 0, 0})
+	assert.Equal(t, rb.length, 3)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'1', '2', '3'})
+
+	assert.True(t, rb.add('4', '5'))
+	assert.Equal(t, rb.runes, []rune{'1', '2', '3', '4', '5'})
+	assert.Equal(t, rb.length, 5)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'1', '2', '3', '4', '5'})
+
+	assert.False(t, rb.add('6'))
+	assert.Equal(t, rb.runes, []rune{'1', '2', '3', '4', '5'})
+	assert.Equal(t, rb.length, 5)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'1', '2', '3', '4', '5'})
+}
+
+func TestRuneBuffer_cr(t *testing.T) {
+	rb := newRuneBuffer(5)
+	assert.Equal(t, rb.runes, []rune{0, 0, 0, 0, 0})
+	assert.Equal(t, rb.length, 0)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{})
+
+	assert.True(t, rb.add('1', '2', '3', '4', '5'))
+	assert.Equal(t, rb.runes, []rune{'1', '2', '3', '4', '5'})
+	assert.Equal(t, rb.length, 5)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'1', '2', '3', '4', '5'})
+
+	rb.cr(3)
+	assert.Equal(t, rb.runes, []rune{'4', '5', '3', '4', '5'})
+	assert.Equal(t, rb.length, 2)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'4', '5'})
+
+	assert.True(t, rb.add('6'))
+	assert.Equal(t, rb.runes, []rune{'4', '5', '6', '4', '5'})
+	assert.Equal(t, rb.length, 3)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'4', '5', '6'})
+
+	rb.cr(3)
+	assert.Equal(t, rb.runes, []rune{'4', '5', '6', '4', '5'})
+	assert.Equal(t, rb.length, 0)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{})
+
+	assert.True(t, rb.add('1', '2', '3', '4', '5'))
+	assert.Equal(t, rb.runes, []rune{'1', '2', '3', '4', '5'})
+	assert.Equal(t, rb.length, 5)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'1', '2', '3', '4', '5'})
+
+	rb.cr(0)
+	assert.False(t, rb.add('1', '2', '3', '4', '5'))
+	assert.Equal(t, rb.runes, []rune{'1', '2', '3', '4', '5'})
+	assert.Equal(t, rb.length, 5)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'1', '2', '3', '4', '5'})
+
+	rb.cr(-1)
+	assert.False(t, rb.add('1', '2', '3', '4', '5'))
+	assert.Equal(t, rb.runes, []rune{'1', '2', '3', '4', '5'})
+	assert.Equal(t, rb.length, 5)
+	assert.Equal(t, len(rb.runes), 5)
+	assert.Equal(t, cap(rb.runes), 5)
+	assert.Equal(t, rb.slice(), []rune{'1', '2', '3', '4', '5'})
+}


### PR DESCRIPTION
This PR adds inner struct type `runeBuffer` , which has fixed size rune buffer and methods to add runes and carriage return.