### PR TITLE
new: added scanLineIter

### DIFF
--- a/line-iter.go
+++ b/line-iter.go
@@ -1,0 +1,139 @@
+// Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+package cliargs
+
+import (
+	"strings"
+	"text/scanner"
+	"unicode"
+)
+
+// IterStatus is a type which indicates an iterator status.
+// If this value is true, a iterator has more items.
+// If this value is false, a iterator has no more items.
+type IterStatus bool
+
+const (
+	ITER_HAS_MORE IterStatus = true  // A iterator has more items.
+	ITER_NO_MORE  IterStatus = false // A iterator has no more items.
+)
+
+type lboType int
+
+const (
+	lbo_before lboType = iota
+	lbo_after
+	lbo_both
+	lbo_never
+	lbo_break
+	lbo_space
+)
+
+type scanLineIter struct {
+	scanner   *scanner.Scanner
+	buffer    runeBuffer
+	lineWidth int
+	lboPos    int
+	indent    string
+}
+
+func newScanLineIter(text string, lineWidth int) scanLineIter {
+	sc := new(scanner.Scanner)
+	sc.Init(strings.NewReader(text))
+
+	iter := scanLineIter{}
+	iter.scanner = sc
+	iter.buffer = newRuneBuffer(lineWidth)
+	iter.lineWidth = lineWidth
+	return iter
+}
+
+func (iter *scanLineIter) setIndent(indent int) {
+	iter.indent = strings.Repeat(" ", indent)
+}
+
+func (iter *scanLineIter) resetText(text string) {
+	iter.scanner.Init(strings.NewReader(text))
+	iter.buffer.length = 0
+}
+
+func (iter *scanLineIter) Next() (string, IterStatus) {
+	lineWidth := iter.lineWidth - len(iter.indent)
+
+	for r := iter.scanner.Next(); r != scanner.EOF; r = iter.scanner.Next() {
+		lboTyp := lineBreakOppotunity(r)
+
+		var line string
+		if lboTyp == lbo_break {
+			line = string(iter.buffer.slice())
+			iter.lboPos = 0
+			iter.buffer.length = 0
+			return iter.indent + line, ITER_HAS_MORE
+		}
+
+		if iter.buffer.length == 0 && lboTyp == lbo_space {
+			continue
+		}
+
+		length := iter.buffer.length + runeWidth(r)
+		lboPos := iter.lboPos
+
+		if length > lineWidth {
+			switch lboTyp {
+			case lbo_before, lbo_both, lbo_space:
+				lboPos = iter.buffer.length
+			}
+			if lboPos == 0 {
+				lboPos = lineWidth
+			}
+
+			line := string(iter.buffer.runes[0:lboPos])
+			iter.buffer.cr(lboPos)
+
+			switch lboTyp {
+			case lbo_space:
+				iter.lboPos = 0
+			case lbo_after, lbo_both:
+				iter.buffer.add(r)
+				iter.lboPos = iter.buffer.length
+			default:
+				iter.buffer.add(r)
+				iter.lboPos = 0
+			}
+
+			return iter.indent + line, ITER_HAS_MORE
+		}
+
+		iter.buffer.add(r)
+		switch lboTyp {
+		case lbo_before:
+			iter.lboPos = iter.buffer.length - 1
+		case lbo_after, lbo_both, lbo_space:
+			iter.lboPos = iter.buffer.length
+		}
+	}
+
+	return iter.indent + string(iter.buffer.slice()), ITER_NO_MORE
+}
+
+func lineBreakOppotunity(r rune) lboType {
+	if r == 0x0a || r == 0x0d {
+		return lbo_break
+	}
+	if unicode.IsSpace(r) {
+		return lbo_space
+	}
+	if unicode.IsPunct(r) {
+		return lbo_after
+	}
+	return lbo_never
+}
+
+func runeWidth(r rune) int {
+	if !unicode.IsPrint(r) {
+		return 0
+	}
+	return 1
+}

--- a/line-iter_test.go
+++ b/line-iter_test.go
@@ -1,0 +1,308 @@
+package cliargs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLineIter_Next_emptyText(t *testing.T) {
+	text := ""
+	iter := newScanLineIter(text, 20)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, text)
+}
+
+func TestLineIter_Next_oneCharText(t *testing.T) {
+	text := "a"
+	iter := newScanLineIter(text, 20)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, text)
+}
+
+func TestLineIter_Next_lessThanLineWidth(t *testing.T) {
+	text := "1234567890123456789"
+	iter := newScanLineIter(text, 20)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, text)
+}
+
+func TestLineIter_Next_equalToLineWidth(t *testing.T) {
+	text := "12345678901234567890"
+	iter := newScanLineIter(text, 20)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, text)
+}
+
+func TestLineIter_Next_breakAtLineBreakOppotunity(t *testing.T) {
+	text := "1234567890 abcdefghij"
+	iter := newScanLineIter(text, 20)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, text[0:11])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, text[11:21])
+}
+
+func TestLineIter_Next_removeHeadingSpaceOfEachLine(t *testing.T) {
+	text := "12345678901234567890   abcdefghij"
+	iter := newScanLineIter(text, 20)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, text[0:20])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, text[23:])
+}
+
+func TestLineIter_Next_thereIsNoLineBreakOppotunity(t *testing.T) {
+	text := "12345678901234567890abcdefghij"
+	iter := newScanLineIter(text, 20)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, text[0:20])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, text[20:])
+}
+
+func TestLineIter_setIndent(t *testing.T) {
+	text := "12345678901234567890abcdefghij"
+	iter := newScanLineIter(text, 10)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, text[0:10])
+
+	iter.setIndent(3)
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "   "+text[10:17])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "   "+text[17:24])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "   "+text[24:])
+}
+
+func TestLineIter_resetText(t *testing.T) {
+	text := "12345678901234567890"
+	iter := newScanLineIter(text, 12)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, text[0:12])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, text[12:])
+
+	text = "abcdefghijklmnopqrstuvwxyz"
+	iter.resetText(text)
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, text[0:12])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, text[12:24])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, text[24:])
+}
+
+// This text is quoted from https://go.dev/doc/
+const longText string = `The Go programming language is an open source project to make programmers more productive.
+
+Go is expressive, concise, clean, and efficient. Its concurrency mechanisms make it easy to write programs that get the most out of multicore and networked machines, while its novel type system enables flexible and modular program construction. Go compiles quickly to machine code yet has the convenience of garbage collection and the power of run-time reflection. It's a fast, statically typed, compiled language that feels like a dynamically typed, interpreted language.`
+
+func TestLineIter_Next_tryLongText(t *testing.T) {
+	iter := newScanLineIter(longText, 20)
+
+	line, status := iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "The Go programming ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "language is an open ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "source project to ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "make programmers ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "more productive.")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "Go is expressive, ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "concise, clean, and ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "efficient. Its ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "concurrency ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "mechanisms make it ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "easy to write ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "programs that get ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "the most out of ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "multicore and ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "networked machines, ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "while its novel type")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "system enables ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "flexible and modular")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "program ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "construction. Go ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "compiles quickly to ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "machine code yet has")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "the convenience of ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "garbage collection ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "and the power of ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "run-time reflection.")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "It's a fast, ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "statically typed, ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "compiled language ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "that feels like a ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "dynamically typed, ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "interpreted ")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "language.")
+}
+
+/*
+func TestLineIter_Next_printLongText(t *testing.T) {
+	iter := newScanLineIter(longText, 20)
+
+	for {
+		line, status := iter.Next()
+		t.Logf("%v\n", line)
+		if status == ITER_NO_MORE {
+			break
+		}
+	}
+}
+
+func TestLineIter_setIndentToLongText(t *testing.T) {
+	iter := newScanLineIter(longText, 40)
+
+	line, status := iter.Next()
+	t.Logf("%v\n", line)
+
+	iter.setIndent(8)
+
+	for {
+		if status == ITER_NO_MORE {
+			break
+		}
+		line, status = iter.Next()
+		t.Logf("%v\n", line)
+	}
+}
+*/


### PR DESCRIPTION
This PR adds a new struct type `scanLineIter` which iterate lines of the given text with scanner.

This `scanLintIter` have functionalities to break lines according to line break oppotunities and each rune width in the given text, but for now this supports only ascii characters.