### PR TITLE
fix: made scanLineIter return ITER_NO_MORE repeatedly after it ended

### DIFF
--- a/line-iter.go
+++ b/line-iter.go
@@ -62,15 +62,19 @@ func (iter *scanLineIter) resetText(text string) {
 func (iter *scanLineIter) Next() (string, IterStatus) {
 	lineWidth := iter.lineWidth - len(iter.indent)
 
+	var line string
+
 	for r := iter.scanner.Next(); r != scanner.EOF; r = iter.scanner.Next() {
 		lboTyp := lineBreakOppotunity(r)
 
-		var line string
 		if lboTyp == lbo_break {
 			line = string(iter.buffer.slice())
 			iter.lboPos = 0
 			iter.buffer.length = 0
-			return iter.indent + line, ITER_HAS_MORE
+			if len(line) > 0 {
+				line = iter.indent + line
+			}
+			return line, ITER_HAS_MORE
 		}
 
 		if iter.buffer.length == 0 && lboTyp == lbo_space {
@@ -103,7 +107,10 @@ func (iter *scanLineIter) Next() (string, IterStatus) {
 				iter.lboPos = 0
 			}
 
-			return iter.indent + line, ITER_HAS_MORE
+			if len(line) > 0 {
+				line = iter.indent + line
+			}
+			return line, ITER_HAS_MORE
 		}
 
 		iter.buffer.add(r)
@@ -115,7 +122,13 @@ func (iter *scanLineIter) Next() (string, IterStatus) {
 		}
 	}
 
-	return iter.indent + string(iter.buffer.slice()), ITER_NO_MORE
+	line = string(iter.buffer.slice())
+	iter.buffer.length = 0
+
+	if len(line) > 0 {
+		line = iter.indent + line
+	}
+	return line, ITER_NO_MORE
 }
 
 func lineBreakOppotunity(r rune) lboType {

--- a/line-iter_test.go
+++ b/line-iter_test.go
@@ -12,6 +12,10 @@ func TestLineIter_Next_emptyText(t *testing.T) {
 	line, status := iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, text)
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 func TestLineIter_Next_oneCharText(t *testing.T) {
@@ -21,6 +25,10 @@ func TestLineIter_Next_oneCharText(t *testing.T) {
 	line, status := iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, text)
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 func TestLineIter_Next_lessThanLineWidth(t *testing.T) {
@@ -30,6 +38,10 @@ func TestLineIter_Next_lessThanLineWidth(t *testing.T) {
 	line, status := iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, text)
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 func TestLineIter_Next_equalToLineWidth(t *testing.T) {
@@ -39,6 +51,10 @@ func TestLineIter_Next_equalToLineWidth(t *testing.T) {
 	line, status := iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, text)
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 func TestLineIter_Next_breakAtLineBreakOppotunity(t *testing.T) {
@@ -52,6 +68,10 @@ func TestLineIter_Next_breakAtLineBreakOppotunity(t *testing.T) {
 	line, status = iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, text[11:21])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 func TestLineIter_Next_removeHeadingSpaceOfEachLine(t *testing.T) {
@@ -65,6 +85,10 @@ func TestLineIter_Next_removeHeadingSpaceOfEachLine(t *testing.T) {
 	line, status = iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, text[23:])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 func TestLineIter_Next_thereIsNoLineBreakOppotunity(t *testing.T) {
@@ -78,6 +102,10 @@ func TestLineIter_Next_thereIsNoLineBreakOppotunity(t *testing.T) {
 	line, status = iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, text[20:])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 func TestLineIter_setIndent(t *testing.T) {
@@ -101,6 +129,10 @@ func TestLineIter_setIndent(t *testing.T) {
 	line, status = iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, "   "+text[24:])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 func TestLineIter_resetText(t *testing.T) {
@@ -129,6 +161,10 @@ func TestLineIter_resetText(t *testing.T) {
 	line, status = iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, text[24:])
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 // This text is quoted from https://go.dev/doc/
@@ -274,6 +310,10 @@ func TestLineIter_Next_tryLongText(t *testing.T) {
 	line, status = iter.Next()
 	assert.Equal(t, status, ITER_NO_MORE)
 	assert.Equal(t, line, "language.")
+
+	line, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "")
 }
 
 /*


### PR DESCRIPTION
This PR makes `scanLineIter#Next` return an empty string and `ITER_NO_MORE` repeatedly after the `scanLineIter` ended.