### PR TITLE
new: added MakeHelp and PrintHelp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.20
 require (
 	github.com/stretchr/testify v1.8.2
 	github.com/sttk-go/sabi v0.2.0
+	golang.org/x/term v0.6.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,10 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/sttk-go/sabi v0.2.0 h1:eXyNcUmv54Kg3BIUOdrk3jNCXvFLp/MEvQriI1NBOwI=
 github.com/sttk-go/sabi v0.2.0/go.mod h1:YcP+oW3jRInzYmFIKXt32gnfAX5PewyNmkCZSbpEo7A=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
+golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parse-with.go
+++ b/parse-with.go
@@ -67,7 +67,7 @@ const anyOption = "*"
 // argument.
 // If this field is nil, nothing is done after parsing.
 //
-// Desc is the field to put the description of the option.
+// Desc is the field to set the description of the option.
 type OptCfg struct {
 	Name     string
 	Aliases  []string

--- a/parse-with.go
+++ b/parse-with.go
@@ -43,7 +43,7 @@ const anyOption = "*"
 
 // OptCfg is a structure that represents an option configuration.
 // An option configuration consists of fields: Name, Aliases, HasParam,
-// IsArray.
+// IsArray, Default, OnParsed, Desc.
 
 // Name is the option name and Aliases are the another names.
 // Options given by those names in command line arguments are all registered to
@@ -66,6 +66,8 @@ const anyOption = "*"
 // This handler receives a string array which is the option parameter(s) as its
 // argument.
 // If this field is nil, nothing is done after parsing.
+//
+// Desc is the field to put the description of the option.
 type OptCfg struct {
 	Name     string
 	Aliases  []string
@@ -73,6 +75,7 @@ type OptCfg struct {
 	IsArray  bool
 	Default  []string
 	OnParsed *func([]string) sabi.Err
+	Desc     string
 }
 
 // ParseWith is a function which parses command line arguments with option

--- a/print-help.go
+++ b/print-help.go
@@ -26,8 +26,8 @@ type /* error reason */ (
 // This struct type has the following field for wrap options: MarginLeft,
 // MarginRight, and Indent.
 // MarginLeft and MarginRight is space widths on both sides, and these are
-// output on all lines.
-// Indent is space width on left side, and this is output on second line or
+// applied to all lines.
+// Indent is a space width on left side, and this is applied to second line or
 // later of each option.
 type WrapOpts struct {
 	MarginLeft  int
@@ -35,7 +35,7 @@ type WrapOpts struct {
 	Indent      int
 }
 
-// HelpIter is a struct type to iterate lines of help texts.
+// HelpIter is a struct type to iterate lines of a help text.
 type HelpIter struct {
 	texts    []string
 	index    int
@@ -56,9 +56,9 @@ func newHelpIter(texts []string, lineWidth, indent, margin int) HelpIter {
 	}
 }
 
-// Next is a method which returns a line of help texts and a status which
+// Next is a method which returns a line of a help text and a status which
 // indicates this HelpIter has more texts or not.
-// If there are more lines, the IterStatus value returned is ITER_HAS_MORE,
+// If there are more lines, the returned IterStatus value is ITER_HAS_MORE,
 // otherwise the value is ITER_NO_MORE.
 func (iter *HelpIter) Next() (string, IterStatus) {
 	if len(iter.texts) == 0 {
@@ -85,9 +85,23 @@ func (iter *HelpIter) Next() (string, IterStatus) {
 	return line, status
 }
 
-// MakeHelp is a function to make a line iterator of help text.
+// MakeHelp is a function to make a line iterator of a help text.
+// This function makes a help text from a usage text, option configurations
+// ([]OptCfg), and wrap options (WrapOpts).
+//
 // A help text consists of an usage section and options section, and options
 // section consists of title parts and description parts.
+// A title part enumerates a option name and aliases, and its description
+// follows the title with an indent, specified in WrapOpts,  in a description
+// part.
+//
+// On the both sides of a help text, left margin and right margin of which size
+// are specified in WrapOpts can be put.
+// These margins are applied to all lines of a help text.
+//
+// The sum of left margin, right margin, and indent have to be less than the
+// line width, because if not, there is no width to output texts.
+// The line width is obtained from the terminal width.
 func MakeHelp(
 	usage string, optCfgs []OptCfg, wrapOpts WrapOpts,
 ) (HelpIter, sabi.Err) {

--- a/print-help.go
+++ b/print-help.go
@@ -1,0 +1,180 @@
+// Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+package cliargs
+
+import (
+	"fmt"
+	"github.com/sttk-go/sabi"
+	"golang.org/x/term"
+	"os"
+	"strings"
+)
+
+type /* error reason */ (
+	// MarginsAndIndentExceedLineWidth is an error reason which indicates that
+	// the sum of left margin, right margin, and indent is greater than line
+	// width.
+	// It means that there are no width to print texts.
+	MarginsAndIndentExceedLineWidth struct {
+		LineWidth, MarginLeft, MarginRight, Indent int
+	}
+)
+
+// WrapOpts is a struct type which holds options for wrapping texts.
+// This struct type has the following field for wrap options: MarginLeft,
+// MarginRight, and Indent.
+// MarginLeft and MarginRight is space widths on both sides, and these are
+// output on all lines.
+// Indent is space width on left side, and this is output on second line or
+// later of each option.
+type WrapOpts struct {
+	MarginLeft  int
+	MarginRight int
+	Indent      int
+}
+
+// HelpIter is a struct type to iterate lines of help texts.
+type HelpIter struct {
+	texts    []string
+	index    int
+	indent   int
+	margin   string
+	lineIter lineIter
+}
+
+func newHelpIter(texts []string, lineWidth, indent, margin int) HelpIter {
+	if len(texts) == 0 {
+		return HelpIter{}
+	}
+	return HelpIter{
+		texts:    texts,
+		indent:   indent,
+		margin:   strings.Repeat(" ", margin),
+		lineIter: newLineIter(texts[0], lineWidth),
+	}
+}
+
+// Next is a method which returns a line of help texts and a status which
+// indicates this HelpIter has more texts or not.
+// If there are more lines, the IterStatus value returned is ITER_HAS_MORE,
+// otherwise the value is ITER_NO_MORE.
+func (iter *HelpIter) Next() (string, IterStatus) {
+	if len(iter.texts) == 0 {
+		return "", ITER_NO_MORE
+	}
+
+	line, status := iter.lineIter.Next()
+	if len(line) > 0 {
+		line = iter.margin + line
+	}
+	if status == ITER_NO_MORE {
+		iter.index++
+		if iter.index >= len(iter.texts) {
+			return line, status
+		}
+		iter.lineIter.resetText(iter.texts[iter.index])
+		iter.lineIter.setIndent(0)
+		return line, ITER_HAS_MORE
+	}
+
+	if iter.index > 0 {
+		iter.lineIter.setIndent(iter.indent)
+	}
+	return line, status
+}
+
+// MakeHelp is a function to make a line iterator of help text.
+// A help text consists of an usage section and options section, and options
+// section consists of title parts and description parts.
+func MakeHelp(
+	usage string, optCfgs []OptCfg, wrapOpts WrapOpts,
+) (HelpIter, sabi.Err) {
+	lineWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
+	if lineWidth <= 0 {
+		lineWidth = 80
+	}
+
+	texts := make([]string, len(optCfgs)+1)
+	indent := 0
+
+	for i, cfg := range optCfgs {
+		t := makeOptTitle(cfg)
+		if indent < len(t) {
+			indent = len(t)
+		}
+		texts[i+1] = t
+	}
+	indent += 2
+
+	if wrapOpts.Indent > 0 {
+		indent = wrapOpts.Indent
+	}
+
+	if (wrapOpts.MarginLeft + wrapOpts.MarginRight + indent) >= lineWidth {
+		return HelpIter{}, sabi.NewErr(MarginsAndIndentExceedLineWidth{
+			LineWidth:   lineWidth,
+			MarginLeft:  wrapOpts.MarginLeft,
+			MarginRight: wrapOpts.MarginRight,
+			Indent:      indent,
+		})
+	}
+	lineWidth -= wrapOpts.MarginLeft + wrapOpts.MarginRight
+
+	texts[0] = usage
+	for i, cfg := range optCfgs {
+		texts[i] += "\n"
+		texts[i+1] = makeOptHelp(texts[i+1], cfg, indent)
+	}
+
+	return newHelpIter(texts, lineWidth, indent, wrapOpts.MarginLeft), sabi.Ok()
+}
+
+func makeOptTitle(cfg OptCfg) string {
+	title := cfg.Name
+	switch len(title) {
+	case 0:
+	case 1:
+		title = "-" + title
+	default:
+		title = "--" + title
+	}
+
+	for _, alias := range cfg.Aliases {
+		switch len(alias) {
+		case 0:
+		case 1:
+			title += ", -" + alias
+		default:
+			title += ", --" + alias
+		}
+	}
+
+	return title
+}
+
+func makeOptHelp(title string, cfg OptCfg, indent int) string {
+	if len(title)+2 > indent {
+		title += "\n" + strings.Repeat(" ", indent) + cfg.Desc
+	} else {
+		title += strings.Repeat(" ", indent-len(title)) + cfg.Desc
+	}
+	return title
+}
+
+func PrintHelp(usage string, optCfgs []OptCfg, wrapOpts WrapOpts) sabi.Err {
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	if !err.IsOk() {
+		return err
+	}
+
+	for {
+		line, status := iter.Next()
+		fmt.Println(line)
+		if status == ITER_NO_MORE {
+			break
+		}
+	}
+	return sabi.Ok()
+}

--- a/print-help.go
+++ b/print-help.go
@@ -177,6 +177,8 @@ func makeOptHelp(title string, cfg OptCfg, indent int) string {
 	return title
 }
 
+// PrintHelp is a function which output a help text to stdout.
+// This function calls MakeHelp function to make a help text inside itself.
 func PrintHelp(usage string, optCfgs []OptCfg, wrapOpts WrapOpts) sabi.Err {
 	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
 	if !err.IsOk() {

--- a/print-help_test.go
+++ b/print-help_test.go
@@ -1,0 +1,501 @@
+package cliargs
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMakeHelp_emptyUsage_noOptCfg_emptyWrapOpts(t *testing.T) {
+	optCfgs := []OptCfg{}
+	wrapOpts := WrapOpts{}
+
+	iter, err := MakeHelp("", optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+}
+
+func TestMakeHelp_shortUsage_noOptCfg_emptyWrapOpts(t *testing.T) {
+	usage := "abcdefghijklmnopqrstuvwxyz"
+	optCfgs := []OptCfg{}
+	wrapOpts := WrapOpts{}
+
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+
+	line, status := iter.Next()
+	assert.Equal(t, line, usage)
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+}
+
+// This text is quoted from https://go.dev/doc/
+const longUsage string = "The Go programming language is an open source project to make programmers more productive."
+
+func TestMakeHelp_longUsage_noOptCfg_emptyWrapOpts(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{}
+	wrapOpts := WrapOpts{}
+
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+
+	line, status := iter.Next()
+	assert.Equal(t, line, usage[0:79])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, usage[79:90])
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+}
+
+func TestMakeHelp_longUsage_oneShortOptCfg_emptyWrapOpts(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{
+		OptCfg{
+			Name: "foo",
+			Desc: "This is the description of --foo option.",
+		},
+	}
+	wrapOpts := WrapOpts{}
+
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+
+	line, status := iter.Next()
+	assert.Equal(t, line, usage[0:79])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, usage[79:90])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "--foo  This is the description of --foo option.")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
+	for {
+		line, status = iter.Next()
+		fmt.Println(line)
+		if status == ITER_NO_MORE {
+			break
+		}
+	}
+}
+
+func TestMakeHelp_longUsage_twoShortAndLongOptCfg_emptyWrapOpts(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{
+		OptCfg{
+			Name: "foo",
+			Desc: "This is the description of --foo option.",
+		},
+		OptCfg{
+			Name:     "bar-baz",
+			Aliases:  []string{"b"},
+			HasParam: true,
+			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+		},
+	}
+	wrapOpts := WrapOpts{}
+
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+
+	line, status := iter.Next()
+	assert.Equal(t, line, usage[0:79])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, usage[79:90])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "--foo          This is the description of --foo option.")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "--bar-baz, -b  This is the description of --bar-baz option. This option takes ")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "               one parameter.")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
+	for {
+		line, status = iter.Next()
+		fmt.Println(line)
+		if status == ITER_NO_MORE {
+			break
+		}
+	}
+}
+
+func TestMakeHelp_longUsage_twoShortAndLongOptCfg_largeIndent(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{
+		OptCfg{
+			Name: "foo",
+			Desc: "This is the description of --foo option.",
+		},
+		OptCfg{
+			Name:     "bar-baz",
+			Aliases:  []string{"b"},
+			HasParam: true,
+			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+		},
+	}
+	wrapOpts := WrapOpts{Indent: 20}
+
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+
+	line, status := iter.Next()
+	assert.Equal(t, line, usage[0:79])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, usage[79:90])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "--foo               This is the description of --foo option.")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "--bar-baz, -b       This is the description of --bar-baz option. This option ")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                    takes one parameter.")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
+	for {
+		line, status = iter.Next()
+		fmt.Println(line)
+		if status == ITER_NO_MORE {
+			break
+		}
+	}
+}
+
+func TestMakeHelp_longUsage_twoShortAndLongOptCfg_shortIndent(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{
+		OptCfg{
+			Name: "foo",
+			Desc: "This is the description of --foo option.",
+		},
+		OptCfg{
+			Name:     "bar-baz",
+			Aliases:  []string{"b"},
+			HasParam: true,
+			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+		},
+	}
+	wrapOpts := WrapOpts{Indent: 10}
+
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+
+	line, status := iter.Next()
+	assert.Equal(t, line, usage[0:79])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, usage[79:90])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "--foo     This is the description of --foo option.")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "--bar-baz, -b")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "          This is the description of --bar-baz option. This option takes one ")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "          parameter.")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
+	for {
+		line, status = iter.Next()
+		fmt.Println(line)
+		if status == ITER_NO_MORE {
+			break
+		}
+	}
+}
+
+func TestMakeHelp_longUsage_twoShortAndLongOptCfg_margins(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{
+		OptCfg{
+			Name: "foo",
+			Desc: "This is the description of --foo option.",
+		},
+		OptCfg{
+			Name:     "bar-baz",
+			Aliases:  []string{"b"},
+			HasParam: true,
+			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+		},
+	}
+	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5}
+
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "     "+usage[0:62])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     "+usage[62:90])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     --foo          This is the description of --foo option.")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     --bar-baz, -b  This is the description of --bar-baz option. This ")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                    option takes one parameter.")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
+	for {
+		line, status = iter.Next()
+		fmt.Println(line)
+		if status == ITER_NO_MORE {
+			break
+		}
+	}
+}
+
+func TestMakeHelp_optNameIsShortAndOptAliasIsLong(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{
+		OptCfg{
+			Name: "foo",
+			Desc: "This is the description of --foo option.",
+		},
+		OptCfg{
+			Name:     "b",
+			Aliases:  []string{"bar-baz"},
+			HasParam: true,
+			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+		},
+	}
+	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5}
+
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "     "+usage[0:62])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     "+usage[62:90])
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     --foo          This is the description of --foo option.")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     -b, --bar-baz  This is the description of --bar-baz option. This ")
+	assert.Equal(t, status, ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                    option takes one parameter.")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+
+	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
+	for {
+		line, status = iter.Next()
+		fmt.Println(line)
+		if status == ITER_NO_MORE {
+			break
+		}
+	}
+}
+
+func TestMakeHelp_marginsAndIndentExceedLineWidth(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{
+		OptCfg{
+			Name: "foo",
+			Desc: "This is the description of --foo option.",
+		},
+		OptCfg{
+			Name:     "b",
+			Aliases:  []string{"bar-baz"},
+			HasParam: true,
+			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+		},
+	}
+	wrapOpts := WrapOpts{MarginLeft: 50, MarginRight: 50, Indent: 10}
+
+	_, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case MarginsAndIndentExceedLineWidth:
+		assert.Equal(t, err.Get("LineWidth"), 80)
+		assert.Equal(t, err.Get("MarginLeft"), 50)
+		assert.Equal(t, err.Get("MarginRight"), 50)
+		assert.Equal(t, err.Get("Indent"), 10)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}
+
+func TestHelpIter_textsIsEmpty(t *testing.T) {
+	iter := newHelpIter([]string{}, 0, 0, 0)
+	line, status := iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, ITER_NO_MORE)
+}
+
+func TestPrintHelp(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{
+		OptCfg{
+			Name: "foo",
+			Desc: "This is the description of --foo option.",
+		},
+		OptCfg{
+			Name:     "b",
+			Aliases:  []string{"bar-baz"},
+			HasParam: true,
+			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+		},
+	}
+	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5, Indent: 10}
+
+	err := PrintHelp(usage, optCfgs, wrapOpts)
+	assert.True(t, err.IsOk())
+}
+
+func TestPrintHelp_error(t *testing.T) {
+	usage := longUsage
+	optCfgs := []OptCfg{
+		OptCfg{
+			Name: "foo",
+			Desc: "This is the description of --foo option.",
+		},
+		OptCfg{
+			Name:     "b",
+			Aliases:  []string{"bar-baz"},
+			HasParam: true,
+			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+		},
+	}
+	wrapOpts := WrapOpts{MarginLeft: 50, MarginRight: 50, Indent: 10}
+
+	err := PrintHelp(usage, optCfgs, wrapOpts)
+	assert.False(t, err.IsOk())
+	switch err.Reason().(type) {
+	case MarginsAndIndentExceedLineWidth:
+		assert.Equal(t, err.Get("LineWidth"), 80)
+		assert.Equal(t, err.Get("MarginLeft"), 50)
+		assert.Equal(t, err.Get("MarginRight"), 50)
+		assert.Equal(t, err.Get("Indent"), 10)
+	default:
+		assert.Fail(t, err.Error())
+	}
+}


### PR DESCRIPTION
This PR adds two functions: `MakeHelp` and `PrintHelp`.

`PrintHelp` output a help text to stdout, and `MakeHelp` makes the text from a usage text, option configurations (`[]OptCfg`), and wrap options (`WrapOpts`). `MakeHelp` function is called in `PrintHelp`.
