### PR TITLE
update: enabled to set OptCfg.Desc from struct tag by ParseFor

### DIFF
--- a/parse-for.go
+++ b/parse-for.go
@@ -98,7 +98,7 @@ type /* error reason */ (
 // Usage example:
 //
 //	type MyOptions struct {
-//	  FooBar bool     `opt:"foo-bar,f"`
+//	  FooBar bool     `opt:"foo-bar,f" optdesc:"foo bar description"`
 //	  Baz    int      `opt:"baz,b=99"`
 //	  Qux    string   `opt:"=XXX"`
 //	  Quux   []string `opt:"quux=[A,B,C]"`
@@ -166,7 +166,6 @@ func MakeOptCfgsFor(options any) ([]OptCfg, sabi.Err) {
 func newOptCfg(fld reflect.StructField) (OptCfg, sabi.Err) {
 	opt := fld.Tag.Get("opt")
 	arr := strings.SplitN(opt, "=", 2)
-
 	names := strings.Split(arr[0], ",")
 
 	var name string
@@ -213,12 +212,15 @@ func newOptCfg(fld reflect.StructField) (OptCfg, sabi.Err) {
 		}
 	}
 
+	desc := fld.Tag.Get("optdesc")
+
 	return OptCfg{
 		Name:     name,
 		Aliases:  aliases,
 		HasParam: hasParam,
 		IsArray:  isArray,
 		Default:  defaults,
+		Desc:     desc,
 	}, sabi.Ok()
 }
 

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -1397,3 +1397,22 @@ func TestMakeOptCfgsFor_multipleOptsAndMultipleArgs(t *testing.T) {
 	assert.Equal(t, options.Quux, []string{"A", "B", "C"})
 	assert.Equal(t, options.Corge, []int{20, 21})
 }
+
+func TestMakeOptCfgsFor_optionDescriptions(t *testing.T) {
+	type MyOptions struct {
+		FooBar bool     `opt:"foo-bar,f" optdesc:"FooBar description"`
+		Baz    int      `opt:"baz,b=99" optdesc:"Baz description"`
+		Qux    string   `opt:"=XXX" optdesc:"Qux description"`
+		Quux   []string `opt:"quux=/[A/B/C]" optdesc:"Quux description"`
+		Corge  []int
+	}
+	options := MyOptions{}
+
+	optCfgs, err0 := cliargs.MakeOptCfgsFor(&options)
+	assert.True(t, err0.IsOk())
+	assert.Equal(t, optCfgs[0].Desc, "FooBar description")
+	assert.Equal(t, optCfgs[1].Desc, "Baz description")
+	assert.Equal(t, optCfgs[2].Desc, "Qux description")
+	assert.Equal(t, optCfgs[3].Desc, "Quux description")
+	assert.Equal(t, optCfgs[4].Desc, "")
+}


### PR DESCRIPTION
This PR makes enable that OptCfg.Desc is set from struct tag `optdesc` by `ParseFor` function.