### PR TITLE
fix: modified fields of FailToParseXXX

### DIFF
--- a/parse-for.go
+++ b/parse-for.go
@@ -20,6 +20,7 @@ type /* error reason */ (
 	// FailToParseInt is an error reaason which indicates that an option
 	// parameter in command line arguments should be an integer but is invalid.
 	FailToParseInt struct {
+		Option  string
 		Field   string
 		Input   string
 		BitSize int
@@ -29,6 +30,7 @@ type /* error reason */ (
 	// parameter in command line arguments should be an unsigned integer but is
 	// invalid.
 	FailToParseUint struct {
+		Option  string
 		Field   string
 		Input   string
 		BitSize int
@@ -38,6 +40,7 @@ type /* error reason */ (
 	// parameter in command line arguments should be a floating point number but
 	// is invalid.
 	FailToParseFloat struct {
+		Option  string
 		Field   string
 		Input   string
 		BitSize int
@@ -209,65 +212,65 @@ func newValueSetter(
 	t := fld.Type()
 	switch t.Kind() {
 	case reflect.Bool:
-		return newBoolSetter(optName, fld)
+		return newBoolSetter(optName, fldName, fld)
 	case reflect.Int:
-		return newIntSetter(optName, fld, strconv.IntSize)
+		return newIntSetter(optName, fldName, fld, strconv.IntSize)
 	case reflect.Int8:
-		return newIntSetter(optName, fld, 8)
+		return newIntSetter(optName, fldName, fld, 8)
 	case reflect.Int16:
-		return newIntSetter(optName, fld, 16)
+		return newIntSetter(optName, fldName, fld, 16)
 	case reflect.Int32:
-		return newIntSetter(optName, fld, 32)
+		return newIntSetter(optName, fldName, fld, 32)
 	case reflect.Int64:
-		return newIntSetter(optName, fld, 64)
+		return newIntSetter(optName, fldName, fld, 64)
 	case reflect.Uint:
-		return newUintSetter(optName, fld, strconv.IntSize)
+		return newUintSetter(optName, fldName, fld, strconv.IntSize)
 	case reflect.Uint8:
-		return newUintSetter(optName, fld, 8)
+		return newUintSetter(optName, fldName, fld, 8)
 	case reflect.Uint16:
-		return newUintSetter(optName, fld, 16)
+		return newUintSetter(optName, fldName, fld, 16)
 	case reflect.Uint32:
-		return newUintSetter(optName, fld, 32)
+		return newUintSetter(optName, fldName, fld, 32)
 	case reflect.Uint64:
-		return newUintSetter(optName, fld, 64)
+		return newUintSetter(optName, fldName, fld, 64)
 	case reflect.Float32:
-		return newFloatSetter(optName, fld, 32)
+		return newFloatSetter(optName, fldName, fld, 32)
 	case reflect.Float64:
-		return newFloatSetter(optName, fld, 64)
+		return newFloatSetter(optName, fldName, fld, 64)
 	case reflect.Array | reflect.Slice:
 		elm := t.Elem()
 		switch elm.Kind() {
 		case reflect.Int:
-			return newIntArraySetter(optName, fld, strconv.IntSize)
+			return newIntArraySetter(optName, fldName, fld, strconv.IntSize)
 		case reflect.Int8:
-			return newIntArraySetter(optName, fld, 8)
+			return newIntArraySetter(optName, fldName, fld, 8)
 		case reflect.Int16:
-			return newIntArraySetter(optName, fld, 16)
+			return newIntArraySetter(optName, fldName, fld, 16)
 		case reflect.Int32:
-			return newIntArraySetter(optName, fld, 32)
+			return newIntArraySetter(optName, fldName, fld, 32)
 		case reflect.Int64:
-			return newIntArraySetter(optName, fld, 64)
+			return newIntArraySetter(optName, fldName, fld, 64)
 		case reflect.Uint:
-			return newUintArraySetter(optName, fld, strconv.IntSize)
+			return newUintArraySetter(optName, fldName, fld, strconv.IntSize)
 		case reflect.Uint8:
-			return newUintArraySetter(optName, fld, 8)
+			return newUintArraySetter(optName, fldName, fld, 8)
 		case reflect.Uint16:
-			return newUintArraySetter(optName, fld, 16)
+			return newUintArraySetter(optName, fldName, fld, 16)
 		case reflect.Uint32:
-			return newUintArraySetter(optName, fld, 32)
+			return newUintArraySetter(optName, fldName, fld, 32)
 		case reflect.Uint64:
-			return newUintArraySetter(optName, fld, 64)
+			return newUintArraySetter(optName, fldName, fld, 64)
 		case reflect.Float32:
-			return newFloatArraySetter(optName, fld, 32)
+			return newFloatArraySetter(optName, fldName, fld, 32)
 		case reflect.Float64:
-			return newFloatArraySetter(optName, fld, 64)
+			return newFloatArraySetter(optName, fldName, fld, 64)
 		case reflect.String:
-			return newStringArraySetter(optName, fld)
+			return newStringArraySetter(optName, fldName, fld)
 		default:
 			return newIllegalOptionTypeErr(optName, fldName, t)
 		}
 	case reflect.String:
-		return newStringSetter(optName, fld)
+		return newStringSetter(optName, fldName, fld)
 	default:
 		return newIllegalOptionTypeErr(optName, fldName, t)
 	}
@@ -281,7 +284,7 @@ func newIllegalOptionTypeErr(
 }
 
 func newBoolSetter(
-	name string, fld reflect.Value,
+	optName string, fldName string, fld reflect.Value,
 ) (func([]string) sabi.Err, sabi.Err) {
 	fn := func(s []string) sabi.Err {
 		if s != nil {
@@ -293,7 +296,7 @@ func newBoolSetter(
 }
 
 func newIntSetter(
-	name string, fld reflect.Value, bitSize int,
+	optName string, fldName string, fld reflect.Value, bitSize int,
 ) (func([]string) sabi.Err, sabi.Err) {
 	fn := func(s []string) sabi.Err {
 		if len(s) == 0 {
@@ -301,7 +304,9 @@ func newIntSetter(
 		}
 		n, e := strconv.ParseInt(s[0], 0, bitSize)
 		if e != nil {
-			r := FailToParseInt{Field: name, Input: s[0], BitSize: bitSize}
+			r := FailToParseInt{
+				Option: optName, Field: fldName, Input: s[0], BitSize: bitSize,
+			}
 			return sabi.NewErr(r, e)
 		}
 		fld.SetInt(n)
@@ -311,7 +316,7 @@ func newIntSetter(
 }
 
 func newUintSetter(
-	name string, fld reflect.Value, bitSize int,
+	optName string, fldName string, fld reflect.Value, bitSize int,
 ) (func([]string) sabi.Err, sabi.Err) {
 	fn := func(s []string) sabi.Err {
 		if len(s) == 0 {
@@ -319,7 +324,9 @@ func newUintSetter(
 		}
 		n, e := strconv.ParseUint(s[0], 0, bitSize)
 		if e != nil {
-			r := FailToParseUint{Field: name, Input: s[0], BitSize: bitSize}
+			r := FailToParseUint{
+				Option: optName, Field: fldName, Input: s[0], BitSize: bitSize,
+			}
 			return sabi.NewErr(r, e)
 		}
 		fld.SetUint(n)
@@ -329,7 +336,7 @@ func newUintSetter(
 }
 
 func newFloatSetter(
-	name string, fld reflect.Value, bitSize int,
+	optName string, fldName string, fld reflect.Value, bitSize int,
 ) (func([]string) sabi.Err, sabi.Err) {
 	fn := func(s []string) sabi.Err {
 		if len(s) == 0 {
@@ -337,7 +344,9 @@ func newFloatSetter(
 		}
 		n, e := strconv.ParseFloat(s[0], bitSize)
 		if e != nil {
-			r := FailToParseFloat{Field: name, Input: s[0], BitSize: bitSize}
+			r := FailToParseFloat{
+				Option: optName, Field: fldName, Input: s[0], BitSize: bitSize,
+			}
 			return sabi.NewErr(r, e)
 		}
 		fld.SetFloat(n)
@@ -347,7 +356,7 @@ func newFloatSetter(
 }
 
 func newStringSetter(
-	name string, fld reflect.Value,
+	optName string, fldName string, fld reflect.Value,
 ) (func([]string) sabi.Err, sabi.Err) {
 	fn := func(s []string) sabi.Err {
 		if len(s) == 0 {
@@ -360,7 +369,7 @@ func newStringSetter(
 }
 
 func newIntArraySetter(
-	name string, fld reflect.Value, bitSize int,
+	optName string, fldName string, fld reflect.Value, bitSize int,
 ) (func([]string) sabi.Err, sabi.Err) {
 	fn := func(s []string) sabi.Err {
 		if s == nil {
@@ -377,7 +386,9 @@ func newIntArraySetter(
 		for i := 0; i < n; i++ {
 			v, e := strconv.ParseInt(s[i], 0, bitSize)
 			if e != nil {
-				r := FailToParseInt{Field: name, Input: s[i], BitSize: bitSize}
+				r := FailToParseInt{
+					Option: optName, Field: fldName, Input: s[i], BitSize: bitSize,
+				}
 				return sabi.NewErr(r, e)
 			}
 			a[i] = reflect.ValueOf(v).Convert(t)
@@ -389,7 +400,7 @@ func newIntArraySetter(
 }
 
 func newUintArraySetter(
-	name string, fld reflect.Value, bitSize int,
+	optName string, fldName string, fld reflect.Value, bitSize int,
 ) (func([]string) sabi.Err, sabi.Err) {
 	fn := func(s []string) sabi.Err {
 		if s == nil {
@@ -406,7 +417,9 @@ func newUintArraySetter(
 		for i := 0; i < n; i++ {
 			v, e := strconv.ParseUint(s[i], 0, bitSize)
 			if e != nil {
-				r := FailToParseUint{Field: name, Input: s[i], BitSize: bitSize}
+				r := FailToParseUint{
+					Option: optName, Field: fldName, Input: s[i], BitSize: bitSize,
+				}
 				return sabi.NewErr(r, e)
 			}
 			a[i] = reflect.ValueOf(v).Convert(t)
@@ -418,7 +431,7 @@ func newUintArraySetter(
 }
 
 func newFloatArraySetter(
-	name string, fld reflect.Value, bitSize int,
+	optName string, fldName string, fld reflect.Value, bitSize int,
 ) (func([]string) sabi.Err, sabi.Err) {
 	fn := func(s []string) sabi.Err {
 		if s == nil {
@@ -435,7 +448,9 @@ func newFloatArraySetter(
 		for i := 0; i < n; i++ {
 			v, e := strconv.ParseFloat(s[i], bitSize)
 			if e != nil {
-				r := FailToParseFloat{Field: name, Input: s[i], BitSize: bitSize}
+				r := FailToParseFloat{
+					Option: optName, Field: fldName, Input: s[i], BitSize: bitSize,
+				}
 				return sabi.NewErr(r, e)
 			}
 			a[i] = reflect.ValueOf(v).Convert(t)
@@ -447,7 +462,7 @@ func newFloatArraySetter(
 }
 
 func newStringArraySetter(
-	name string, fld reflect.Value,
+	optName string, fldName string, fld reflect.Value,
 ) (func([]string) sabi.Err, sabi.Err) {
 	fn := func(s []string) sabi.Err {
 		if s == nil {

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -1113,7 +1113,7 @@ func TestParseFor_ignoreEmptyDefaultValueIfOptionIsBool(t *testing.T) {
 
 func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
 	type MyOptions struct {
-		IntVar int `opt:"="`
+		IntVar int `opt:"int-var="`
 	}
 	options := MyOptions{}
 
@@ -1124,6 +1124,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.FailToParseInt:
+		assert.Equal(t, err.Get("Option"), "int-var")
 		assert.Equal(t, err.Get("Field"), "IntVar")
 		assert.Equal(t, err.Get("Input"), "")
 		assert.Equal(t, err.Get("BitSize"), 64)
@@ -1134,7 +1135,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
 
 func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
 	type MyOptions struct {
-		UintVar uint `opt:"="`
+		UintVar uint `opt:"uint-var="`
 	}
 	options := MyOptions{}
 
@@ -1145,6 +1146,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.FailToParseUint:
+		assert.Equal(t, err.Get("Option"), "uint-var")
 		assert.Equal(t, err.Get("Field"), "UintVar")
 		assert.Equal(t, err.Get("Input"), "")
 		assert.Equal(t, err.Get("BitSize"), 64)
@@ -1155,7 +1157,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
 
 func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
 	type MyOptions struct {
-		Float64Var float64 `opt:"="`
+		Float64Var float64 `opt:"float-var="`
 	}
 	options := MyOptions{}
 
@@ -1166,6 +1168,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.FailToParseFloat:
+		assert.Equal(t, err.Get("Option"), "float-var")
 		assert.Equal(t, err.Get("Field"), "Float64Var")
 		assert.Equal(t, err.Get("Input"), "")
 		assert.Equal(t, err.Get("BitSize"), 64)
@@ -1176,7 +1179,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
 
 func TestParseFor_errorEmptyDefaultValueIfOptionIsString(t *testing.T) {
 	type MyOptions struct {
-		StringVar string `opt:"="`
+		StringVar string `opt:"str-var="`
 	}
 	options := MyOptions{}
 
@@ -1190,7 +1193,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsString(t *testing.T) {
 
 func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
 	type MyOptions struct {
-		IntArr []int `opt:"="`
+		IntArr []int `opt:"int-arr="`
 	}
 	options := MyOptions{}
 
@@ -1201,6 +1204,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.FailToParseInt:
+		assert.Equal(t, err.Get("Option"), "int-arr")
 		assert.Equal(t, err.Get("Field"), "IntArr")
 		assert.Equal(t, err.Get("Input"), "")
 		assert.Equal(t, err.Get("BitSize"), 64)
@@ -1211,7 +1215,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
 
 func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
 	type MyOptions struct {
-		UintArr []uint `opt:"="`
+		UintArr []uint `opt:"uint-arr="`
 	}
 	options := MyOptions{}
 
@@ -1222,6 +1226,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.FailToParseUint:
+		assert.Equal(t, err.Get("Option"), "uint-arr")
 		assert.Equal(t, err.Get("Field"), "UintArr")
 		assert.Equal(t, err.Get("Input"), "")
 		assert.Equal(t, err.Get("BitSize"), 64)
@@ -1232,7 +1237,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
 
 func TestParseFor_errorEmptyDefaultValueIfOptionIsFloatArray(t *testing.T) {
 	type MyOptions struct {
-		Float64Arr []float64 `opt:"="`
+		Float64Arr []float64 `opt:"float-arr="`
 	}
 	options := MyOptions{}
 
@@ -1243,6 +1248,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloatArray(t *testing.T) {
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
 	case cliargs.FailToParseFloat:
+		assert.Equal(t, err.Get("Option"), "float-arr")
 		assert.Equal(t, err.Get("Field"), "Float64Arr")
 		assert.Equal(t, err.Get("Input"), "")
 		assert.Equal(t, err.Get("BitSize"), 64)


### PR DESCRIPTION
This PR fixes the issue that an option name is set to Field of `FailToParseXXX`.
By this modification, `FailToParseXXX` has both fields, Field and Option.