### PR TITLE
update: removed an extra error in `MakeOptCfgsFor`

### DIFF
--- a/parse-for.go
+++ b/parse-for.go
@@ -128,10 +128,8 @@ func MakeOptCfgsFor(options any) ([]OptCfg, sabi.Err) {
 	var err sabi.Err
 
 	for i := 0; i < n; i++ {
-		optCfgs[i], err = newOptCfg(t.Field(i))
-		if !err.IsOk() {
-			return nil, err
-		}
+		optCfgs[i] = newOptCfg(t.Field(i))
+
 		var setter func([]string) sabi.Err
 		setter, err = newValueSetter(optCfgs[i].Name, t.Field(i).Name, v.Field(i))
 		if !err.IsOk() {
@@ -143,7 +141,7 @@ func MakeOptCfgsFor(options any) ([]OptCfg, sabi.Err) {
 	return optCfgs, sabi.Ok()
 }
 
-func newOptCfg(fld reflect.StructField) (OptCfg, sabi.Err) {
+func newOptCfg(fld reflect.StructField) OptCfg {
 	opt := fld.Tag.Get("opt")
 	arr := strings.SplitN(opt, "=", 2)
 	names := strings.Split(arr[0], ",")
@@ -201,7 +199,7 @@ func newOptCfg(fld reflect.StructField) (OptCfg, sabi.Err) {
 		IsArray:  isArray,
 		Default:  defaults,
 		Desc:     desc,
-	}, sabi.Ok()
+	}
 }
 
 func newValueSetter(

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -1404,6 +1404,25 @@ func TestMakeOptCfgsFor_multipleOptsAndMultipleArgs(t *testing.T) {
 	assert.Equal(t, options.Corge, []int{20, 21})
 }
 
+func TestParseFor_emptyArrayOfDefaultValueWithNotCommaSeparator(t *testing.T) {
+	type MyOptions struct {
+		Foo []int     `opt:"foo=/[]"`
+		Bar []uint    `opt:"bar=|[]"`
+		Baz []float64 `opt:"baz=@[]"`
+		Qux []string  `opt:"baz=![]"`
+	}
+	options := MyOptions{}
+
+	args := []string{}
+	cmdParams, err := cliargs.ParseFor(args, &options)
+	assert.True(t, err.IsOk())
+	assert.Equal(t, cmdParams, []string{})
+	assert.Equal(t, options.Foo, []int{})
+	assert.Equal(t, options.Bar, []uint{})
+	assert.Equal(t, options.Baz, []float64{})
+	assert.Equal(t, options.Qux, []string{})
+}
+
 func TestMakeOptCfgsFor_optionDescriptions(t *testing.T) {
 	type MyOptions struct {
 		FooBar bool     `opt:"foo-bar,f" optdesc:"FooBar description"`


### PR DESCRIPTION
This PR removes a necessary error return in `MakeOptCfgsFor` function.

By this modification, the unit test coverage of `parse-for.go` reaches 100%.