### PR TITLE
update: drop sabi from dependencies

### DIFF
--- a/example_parse-for_test.go
+++ b/example_parse-for_test.go
@@ -21,7 +21,7 @@ func ExampleParseFor() {
 	}
 
 	cmdParams, err := cliargs.ParseFor(osArgs, &options)
-	fmt.Printf("err.IsOk() = %v\n", err.IsOk())
+	fmt.Printf("err = %v\n", err)
 	fmt.Printf("cmdParams = %v\n", cmdParams)
 	fmt.Printf("options.FooBar = %v\n", options.FooBar)
 	fmt.Printf("options.Baz = %v\n", options.Baz)
@@ -30,7 +30,7 @@ func ExampleParseFor() {
 	fmt.Printf("options.Corge = %v\n", options.Corge)
 
 	// Output:
-	// err.IsOk() = true
+	// err = <nil>
 	// cmdParams = [c1 c2]
 	// options.FooBar = true
 	// options.Baz = 12
@@ -50,7 +50,7 @@ func ExampleMakeOptCfgsFor() {
 	options := MyOptions{}
 
 	optCfgs, err := cliargs.MakeOptCfgsFor(&options)
-	fmt.Printf("err.IsOk() = %v\n", err.IsOk())
+	fmt.Printf("err = %v\n", err)
 	fmt.Printf("len(optCfgs) = %v\n", len(optCfgs))
 	fmt.Println()
 	fmt.Printf("optCfgs[0].Name = %v\n", optCfgs[0].Name)
@@ -89,7 +89,7 @@ func ExampleMakeOptCfgsFor() {
 	fmt.Printf("optCfgs[4].Desc = %v\n", optCfgs[4].Desc)
 
 	// Output:
-	// err.IsOk() = true
+	// err = <nil>
 	// len(optCfgs) = 5
 	//
 	// optCfgs[0].Name = foo-bar

--- a/example_parse-with_test.go
+++ b/example_parse-with_test.go
@@ -28,7 +28,7 @@ func ExampleParseWith() {
 	}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	fmt.Printf("err.IsOk() = %v\n", err.IsOk())
+	fmt.Printf("err = %v\n", err)
 	fmt.Printf("args.HasOpt(\"foo-bar\") = %v\n", args.HasOpt("foo-bar"))
 	fmt.Printf("args.HasOpt(\"baz\") = %v\n", args.HasOpt("baz"))
 	fmt.Printf("args.HasOpt(\"X\") = %v\n", args.HasOpt("X"))
@@ -40,7 +40,7 @@ func ExampleParseWith() {
 	fmt.Printf("args.CmdParams() = %v\n", args.CmdParams())
 
 	// Output:
-	// err.IsOk() = true
+	// err = <nil>
 	// args.HasOpt("foo-bar") = true
 	// args.HasOpt("baz") = true
 	// args.HasOpt("X") = true

--- a/example_parse_test.go
+++ b/example_parse_test.go
@@ -12,7 +12,7 @@ func ExampleParse() {
 	}
 
 	args, err := cliargs.Parse()
-	fmt.Printf("err.IsOk() = %v\n", err.IsOk())
+	fmt.Printf("err = %v\n", err)
 	fmt.Printf("args.HasOpt(\"a\") = %v\n", args.HasOpt("a"))
 	fmt.Printf("args.HasOpt(\"b\") = %v\n", args.HasOpt("b"))
 	fmt.Printf("args.HasOpt(\"c\") = %v\n", args.HasOpt("c"))
@@ -25,7 +25,7 @@ func ExampleParse() {
 	fmt.Printf("args.CmdParams() = %v\n", args.CmdParams())
 
 	// Output:
-	// err.IsOk() = true
+	// err = <nil>
 	// args.HasOpt("a") = true
 	// args.HasOpt("b") = true
 	// args.HasOpt("c") = true

--- a/example_print-help_test.go
+++ b/example_print-help_test.go
@@ -18,7 +18,7 @@ func ExamplePrintHelp() {
 
 	usage := "This is the usage section."
 	err := cliargs.PrintHelp(usage, optCfgs, wrapOpts)
-	fmt.Printf("\nerr.IsOk() = %v\n", err.IsOk())
+	fmt.Printf("\nerr = %v\n", err)
 
 	// Output:
 	//      This is the usage section.
@@ -34,7 +34,7 @@ func ExamplePrintHelp() {
 	//
 	//      --quux    Quux is a string array.
 	//
-	// err.IsOk() = true
+	// err = <nil>
 }
 
 func ExampleMakeHelp() {
@@ -50,7 +50,7 @@ func ExampleMakeHelp() {
 
 	usage := "This is the usage section."
 	iter, err := cliargs.MakeHelp(usage, optCfgs, wrapOpts)
-	fmt.Printf("\nerr.IsOk() = %v\n", err.IsOk())
+	fmt.Printf("\nerr = %v\n", err)
 
 	for {
 		line, status := iter.Next()
@@ -61,7 +61,7 @@ func ExampleMakeHelp() {
 	}
 
 	// Output:
-	// err.IsOk() = true
+	// err = <nil>
 	//      This is the usage section.
 	//
 	//      --foo-bar, -f  FooBar is a flag.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.2
-	github.com/sttk-go/sabi v0.2.0
 	golang.org/x/term v0.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/sttk-go/sabi v0.2.0 h1:eXyNcUmv54Kg3BIUOdrk3jNCXvFLp/MEvQriI1NBOwI=
-github.com/sttk-go/sabi v0.2.0/go.mod h1:YcP+oW3jRInzYmFIKXt32gnfAX5PewyNmkCZSbpEo7A=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -1,6 +1,7 @@
 package cliargs_test
 
 import (
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/sttk-go/cliargs"
 	"reflect"
@@ -12,7 +13,7 @@ func TestParseFor_emptyOptionStoreAndNoArgs(t *testing.T) {
 	args := []string{}
 	options := MyOptions{}
 	cmdParams, err := cliargs.ParseFor(args, &options)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{})
 }
 
@@ -50,7 +51,7 @@ func TestParseFor_nonEmptyOptionStoreAndNoArgs(t *testing.T) {
 
 	args := []string{}
 	cmdParams, err := cliargs.ParseFor(args, &options)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{})
 	assert.False(t, options.BoolVal)
 	assert.Equal(t, options.IntVal, 0)
@@ -143,7 +144,7 @@ func TestParseFor_dontOverwriteOptionsIfNoArgs(t *testing.T) {
 
 	args := []string{}
 	cmdParams, err := cliargs.ParseFor(args, &options)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{})
 	assert.True(t, options.BoolVal)
 	assert.Equal(t, options.IntVal, 111)
@@ -183,7 +184,7 @@ func TestParseFor_optionIsBoolAndArgIsName(t *testing.T) {
 	args := []string{"--flag", "abc"}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.True(t, options.Flag)
 }
@@ -197,7 +198,7 @@ func TestParseFor_optionIsBoolAndArgIsAlias(t *testing.T) {
 	args := []string{"-f", "abc"}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.True(t, options.Flag)
 }
@@ -222,7 +223,7 @@ func TestParseFor_optionsAreIntAndArgsAreNames(t *testing.T) {
 	}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.Equal(t, options.IntVal, 1)
 	assert.Equal(t, options.Int8Val, int8(2))
@@ -251,7 +252,7 @@ func TestParseFor_optionsAreIntAndArgsAreAliases(t *testing.T) {
 	}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.Equal(t, options.IntVal, 1)
 	assert.Equal(t, options.Int8Val, int8(2))
@@ -280,7 +281,7 @@ func TestParseFor_optionsAreUintAndArgsAreNames(t *testing.T) {
 	}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.Equal(t, options.UintVal, uint(1))
 	assert.Equal(t, options.Uint8Val, uint8(2))
@@ -309,7 +310,7 @@ func TestParseFor_optionsAreUintAndArgsAreAliases(t *testing.T) {
 	}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.Equal(t, options.UintVal, uint(1))
 	assert.Equal(t, options.Uint8Val, uint8(2))
@@ -332,7 +333,7 @@ func TestParseFor_optionsAreFloatAndArgsAreNames(t *testing.T) {
 	}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.Equal(t, options.Float32Val, float32(0.1234))
 	assert.Equal(t, options.Float64Val, 0.5678)
@@ -352,7 +353,7 @@ func TestParseFor_optionsAreFloatAndArgsAreAliases(t *testing.T) {
 	}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.Equal(t, options.Float32Val, float32(0.1234))
 	assert.Equal(t, options.Float64Val, 0.5678)
@@ -370,7 +371,7 @@ func TestParseFor_optionsAreStringAndArgsAreNames(t *testing.T) {
 	}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.Equal(t, options.StringVal, "def")
 }
@@ -387,7 +388,7 @@ func TestParseFor_optionsAreStringAndArgsAreAliases(t *testing.T) {
 	}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
 	assert.Equal(t, options.StringVal, "def")
 }
@@ -405,7 +406,7 @@ func TestParseFor_defaultValueIsInt(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntVal, 11)
 	assert.Equal(t, options.Int8Val, int8(22))
@@ -427,7 +428,7 @@ func TestParseFor_defaultValueIsNegativeInt(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntVal, -11)
 	assert.Equal(t, options.Int8Val, int8(-22))
@@ -449,7 +450,7 @@ func TestParseFor_defaultValueIsUint(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.UintVal, uint(11))
 	assert.Equal(t, options.Uint8Val, uint8(22))
@@ -468,7 +469,7 @@ func TestParseFor_defaultValueIsFloat(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Val, float32(0.123))
 	assert.Equal(t, options.Float64Val, float64(0.456789))
@@ -484,7 +485,7 @@ func TestParseFor_defaultValueIsNegativeFloat(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Val, float32(-0.123))
 	assert.Equal(t, options.Float64Val, float64(-0.456789))
@@ -503,7 +504,7 @@ func TestParseFor_defaultValueIsIntArrayAndSize0(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntArr, []int{})
 	assert.Equal(t, options.Int8Arr, []int8{})
@@ -531,7 +532,7 @@ func TestParseFor_overwriteIntArrayWithDefaultValueIfSize0(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntArr, []int{})
 	assert.Equal(t, options.Int8Arr, []int8{})
@@ -553,7 +554,7 @@ func TestParseFor_defaultValueIsIntArrayAndSize1(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntArr, []int{1})
 	assert.Equal(t, options.Int8Arr, []int8{2})
@@ -581,7 +582,7 @@ func TestParseFor_overwriteIntArrayWithDefaultValueIfSize1(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntArr, []int{1})
 	assert.Equal(t, options.Int8Arr, []int8{2})
@@ -603,7 +604,7 @@ func TestParseFor_defaultValueIsIntArrayAndSize2(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntArr, []int{1, 2})
 	assert.Equal(t, options.Int8Arr, []int8{2, 3})
@@ -631,7 +632,7 @@ func TestParseFor_overwriteIntArrayWithDefaultValueIfSize2(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntArr, []int{1, 2})
 	assert.Equal(t, options.Int8Arr, []int8{2, 3})
@@ -653,7 +654,7 @@ func TestParseFor_defaultValueIsNegativeIntArray(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntArr, []int{-1, -2})
 	assert.Equal(t, options.Int8Arr, []int8{-2, -3})
@@ -675,7 +676,7 @@ func TestParseFor_defaultValueIsIntArraySeparatedByColons(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.IntArr, []int{-1, -2})
 	assert.Equal(t, options.Int8Arr, []int8{-2, -3})
@@ -697,7 +698,7 @@ func TestParseFor_defaultValueIsUintArrayAndSize0(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.UintArr, []uint{})
 	assert.Equal(t, options.Uint8Arr, []uint8{})
@@ -725,7 +726,7 @@ func TestParseFor_overwriteUintArrayWithDefaultValueIfSize0(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.UintArr, []uint{})
 	assert.Equal(t, options.Uint8Arr, []uint8{})
@@ -747,7 +748,7 @@ func TestParseFor_defaultValueIsUintArrayAndSize1(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.UintArr, []uint{1})
 	assert.Equal(t, options.Uint8Arr, []uint8{2})
@@ -775,7 +776,7 @@ func TestParseFor_overwriteUintArrayWithDefaultValueIfSize1(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.UintArr, []uint{1})
 	assert.Equal(t, options.Uint8Arr, []uint8{2})
@@ -797,7 +798,7 @@ func TestParseFor_defaultValueIsUintArrayAndSize2(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.UintArr, []uint{1, 2})
 	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
@@ -825,7 +826,7 @@ func TestParseFor_overwriteUintArrayWithDefaultValueIfSize2(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.UintArr, []uint{1, 2})
 	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
@@ -847,7 +848,7 @@ func TestParseFor_defaultValueIsUintArraySeparatedByColons(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.UintArr, []uint{1, 2})
 	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
@@ -866,7 +867,7 @@ func TestParseFor_defaultValueIsFloatArrayAndSize0(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Arr, []float32{})
 	assert.Equal(t, options.Float64Arr, []float64{})
@@ -885,7 +886,7 @@ func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize0(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Arr, []float32{})
 	assert.Equal(t, options.Float64Arr, []float64{})
@@ -901,7 +902,7 @@ func TestParseFor_defaultValueIsFloatArrayAndSize1(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Arr, []float32{0.1})
 	assert.Equal(t, options.Float64Arr, []float64{0.2})
@@ -920,7 +921,7 @@ func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize1(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Arr, []float32{0.1})
 	assert.Equal(t, options.Float64Arr, []float64{0.2})
@@ -936,7 +937,7 @@ func TestParseFor_defaultValueIsFloatArrayAndSize2(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
 	assert.Equal(t, options.Float64Arr, []float64{0.3, 0.4})
@@ -955,7 +956,7 @@ func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize2(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
 	assert.Equal(t, options.Float64Arr, []float64{0.3, 0.4})
@@ -971,7 +972,7 @@ func TestParseFor_defaultValueIsNegativeFloatArray(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
 	assert.Equal(t, options.Float64Arr, []float64{-0.3, -0.4})
@@ -987,7 +988,7 @@ func TestParseFor_defaultValueIsFloatArraySeparatedByColons(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
 	assert.Equal(t, options.Float64Arr, []float64{-0.3, -0.4})
@@ -1002,7 +1003,7 @@ func TestParseFor_defaultValueIsStringAndSize0(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.StringArr, []string{})
 }
@@ -1018,7 +1019,7 @@ func TestParseFor_overwriteStringArrayWithDefaultValueIfSize0(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.StringArr, []string{})
 }
@@ -1032,7 +1033,7 @@ func TestParseFor_defaultValueIsStringArrayAndSize1(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.StringArr, []string{"ABC"})
 }
@@ -1048,7 +1049,7 @@ func TestParseFor_overwriteStringArrayWithDefaultValueIfSize1(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.StringArr, []string{"ABC"})
 }
@@ -1062,7 +1063,7 @@ func TestParseFor_defaultValueIsStringArrayAndSize2(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
 }
@@ -1078,7 +1079,7 @@ func TestParseFor_overwriteStringArrayWithDefaultValueIfSize2(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
 }
@@ -1092,7 +1093,7 @@ func TestParseFor_defaultValueIsStringArraySeparatedByColons(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
 }
@@ -1106,7 +1107,7 @@ func TestParseFor_ignoreEmptyDefaultValueIfOptionIsBool(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.False(t, options.BoolVar)
 }
@@ -1121,13 +1122,15 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
 	params, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "FailToParseInt")
+	assert.NotNil(t, errors.Unwrap(err))
+	switch err.(type) {
 	case cliargs.FailToParseInt:
-		assert.Equal(t, err.Get("Option"), "int-var")
-		assert.Equal(t, err.Get("Field"), "IntVar")
-		assert.Equal(t, err.Get("Input"), "")
-		assert.Equal(t, err.Get("BitSize"), 64)
+		assert.Equal(t, err.(cliargs.FailToParseInt).Option, "int-var")
+		assert.Equal(t, err.(cliargs.FailToParseInt).Field, "IntVar")
+		assert.Equal(t, err.(cliargs.FailToParseInt).Input, "")
+		assert.Equal(t, err.(cliargs.FailToParseInt).BitSize, 64)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1143,13 +1146,15 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
 	params, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "FailToParseUint")
+	assert.NotNil(t, errors.Unwrap(err))
+	switch err.(type) {
 	case cliargs.FailToParseUint:
-		assert.Equal(t, err.Get("Option"), "uint-var")
-		assert.Equal(t, err.Get("Field"), "UintVar")
-		assert.Equal(t, err.Get("Input"), "")
-		assert.Equal(t, err.Get("BitSize"), 64)
+		assert.Equal(t, err.(cliargs.FailToParseUint).Option, "uint-var")
+		assert.Equal(t, err.(cliargs.FailToParseUint).Field, "UintVar")
+		assert.Equal(t, err.(cliargs.FailToParseUint).Input, "")
+		assert.Equal(t, err.(cliargs.FailToParseUint).BitSize, 64)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1165,13 +1170,15 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
 	params, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "FailToParseFloat")
+	assert.NotNil(t, errors.Unwrap(err))
+	switch err.(type) {
 	case cliargs.FailToParseFloat:
-		assert.Equal(t, err.Get("Option"), "float-var")
-		assert.Equal(t, err.Get("Field"), "Float64Var")
-		assert.Equal(t, err.Get("Input"), "")
-		assert.Equal(t, err.Get("BitSize"), 64)
+		assert.Equal(t, err.(cliargs.FailToParseFloat).Option, "float-var")
+		assert.Equal(t, err.(cliargs.FailToParseFloat).Field, "Float64Var")
+		assert.Equal(t, err.(cliargs.FailToParseFloat).Input, "")
+		assert.Equal(t, err.(cliargs.FailToParseFloat).BitSize, 64)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1186,7 +1193,7 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsString(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.StringVar, "")
 }
@@ -1201,13 +1208,15 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
 	params, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "FailToParseInt")
+	assert.NotNil(t, errors.Unwrap(err))
+	switch err.(type) {
 	case cliargs.FailToParseInt:
-		assert.Equal(t, err.Get("Option"), "int-arr")
-		assert.Equal(t, err.Get("Field"), "IntArr")
-		assert.Equal(t, err.Get("Input"), "")
-		assert.Equal(t, err.Get("BitSize"), 64)
+		assert.Equal(t, err.(cliargs.FailToParseInt).Option, "int-arr")
+		assert.Equal(t, err.(cliargs.FailToParseInt).Field, "IntArr")
+		assert.Equal(t, err.(cliargs.FailToParseInt).Input, "")
+		assert.Equal(t, err.(cliargs.FailToParseInt).BitSize, 64)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1223,13 +1232,15 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
 	params, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "FailToParseUint")
+	assert.NotNil(t, errors.Unwrap(err))
+	switch err.(type) {
 	case cliargs.FailToParseUint:
-		assert.Equal(t, err.Get("Option"), "uint-arr")
-		assert.Equal(t, err.Get("Field"), "UintArr")
-		assert.Equal(t, err.Get("Input"), "")
-		assert.Equal(t, err.Get("BitSize"), 64)
+		assert.Equal(t, err.(cliargs.FailToParseUint).Option, "uint-arr")
+		assert.Equal(t, err.(cliargs.FailToParseUint).Field, "UintArr")
+		assert.Equal(t, err.(cliargs.FailToParseUint).Input, "")
+		assert.Equal(t, err.(cliargs.FailToParseUint).BitSize, 64)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1245,13 +1256,15 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloatArray(t *testing.T) {
 	params, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "FailToParseFloat")
+	assert.NotNil(t, errors.Unwrap(err))
+	switch err.(type) {
 	case cliargs.FailToParseFloat:
-		assert.Equal(t, err.Get("Option"), "float-arr")
-		assert.Equal(t, err.Get("Field"), "Float64Arr")
-		assert.Equal(t, err.Get("Input"), "")
-		assert.Equal(t, err.Get("BitSize"), 64)
+		assert.Equal(t, err.(cliargs.FailToParseFloat).Option, "float-arr")
+		assert.Equal(t, err.(cliargs.FailToParseFloat).Field, "Float64Arr")
+		assert.Equal(t, err.(cliargs.FailToParseFloat).Input, "")
+		assert.Equal(t, err.(cliargs.FailToParseFloat).BitSize, 64)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1266,7 +1279,7 @@ func TestParseFor_optionIsStringArrayAndSetOneEmptyStringByDefaultArray(t *testi
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, options.StringArr, []string{""})
 }
@@ -1280,7 +1293,7 @@ func TestParseFor_defaultValueIsIgnoreWhenTypeIsBool(t *testing.T) {
 	args := []string{}
 	params, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
 	assert.False(t, options.BoolVar)
 }
@@ -1295,11 +1308,12 @@ func TestParseFor_errorIfDefaultValueIsInvalidType(t *testing.T) {
 	params, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "IllegalOptionType")
+	switch err.(type) {
 	case cliargs.IllegalOptionType:
-		assert.Equal(t, err.Get("Field"), "BoolArr")
-		assert.Equal(t, err.Get("Type"), reflect.TypeOf(options.BoolArr))
+		assert.Equal(t, err.(cliargs.IllegalOptionType).Field, "BoolArr")
+		assert.Equal(t, err.(cliargs.IllegalOptionType).Type, reflect.TypeOf(options.BoolArr))
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1322,7 +1336,7 @@ func TestParseFor_multipleOptsAndMultipleArgs(t *testing.T) {
 
 	cmdParams, err := cliargs.ParseFor(args, &options)
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{"c1", "c2"})
 	assert.True(t, options.FooBar)
 	assert.Equal(t, options.Baz, 12)
@@ -1347,7 +1361,7 @@ func TestMakeOptCfgsFor_multipleOptsAndMultipleArgs(t *testing.T) {
 	}
 
 	optCfgs, err0 := cliargs.MakeOptCfgsFor(&options)
-	assert.True(t, err0.IsOk())
+	assert.Nil(t, err0)
 	assert.Equal(t, optCfgs[0].Name, "foo-bar")
 	assert.Equal(t, optCfgs[0].Aliases, []string{"f"})
 	assert.False(t, optCfgs[0].HasParam)
@@ -1380,7 +1394,7 @@ func TestMakeOptCfgsFor_multipleOptsAndMultipleArgs(t *testing.T) {
 	assert.NotNil(t, optCfgs[4].OnParsed)
 
 	a, err1 := cliargs.ParseWith(args, optCfgs)
-	assert.True(t, err1.IsOk())
+	assert.Nil(t, err1)
 	assert.Equal(t, a.CmdParams(), []string{"c1", "c2"})
 	assert.True(t, a.HasOpt("foo-bar"))
 	assert.True(t, a.HasOpt("baz"))
@@ -1415,7 +1429,7 @@ func TestParseFor_emptyArrayOfDefaultValueWithNotCommaSeparator(t *testing.T) {
 
 	args := []string{}
 	cmdParams, err := cliargs.ParseFor(args, &options)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{})
 	assert.Equal(t, options.Foo, []int{})
 	assert.Equal(t, options.Bar, []uint{})
@@ -1434,7 +1448,7 @@ func TestMakeOptCfgsFor_optionDescriptions(t *testing.T) {
 	options := MyOptions{}
 
 	optCfgs, err0 := cliargs.MakeOptCfgsFor(&options)
-	assert.True(t, err0.IsOk())
+	assert.Nil(t, err0)
 	assert.Equal(t, optCfgs[0].Desc, "FooBar description")
 	assert.Equal(t, optCfgs[1].Desc, "Baz description")
 	assert.Equal(t, optCfgs[2].Desc, "Qux description")
@@ -1451,12 +1465,13 @@ func TestParseFor_optCfgHasUnsupportedType(t *testing.T) {
 	options := MyOptions{}
 
 	_, err := cliargs.MakeOptCfgsFor(&options)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "IllegalOptionType")
+	switch err.(type) {
 	case cliargs.IllegalOptionType:
-		assert.Equal(t, err.Get("Option"), "foo-bar")
-		assert.Equal(t, err.Get("Field"), "FooBar")
-		assert.Equal(t, err.Get("Type").(reflect.Type).Name(), "A")
+		assert.Equal(t, err.(cliargs.IllegalOptionType).Option, "foo-bar")
+		assert.Equal(t, err.(cliargs.IllegalOptionType).Field, "FooBar")
+		assert.Equal(t, err.(cliargs.IllegalOptionType).Type.(reflect.Type).Name(), "A")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -1474,8 +1489,9 @@ func TestParseFor_argIsNotPointer(t *testing.T) {
 
 	_, err := cliargs.MakeOptCfgsFor(options)
 
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionStoreIsNotChangeable")
+	switch err.(type) {
 	case cliargs.OptionStoreIsNotChangeable:
 	default:
 		assert.Fail(t, err.Error())

--- a/parse-with.go
+++ b/parse-with.go
@@ -4,40 +4,58 @@
 
 package cliargs
 
-import (
-	"github.com/sttk-go/sabi"
-)
+// ConfigIsArrayButHasNoParam is an error which indicates that an option
+// configuration contradicts that the option must be an array
+// (.IsArray = true) but must have no option parameter (.HasParam = false).
+type ConfigIsArrayButHasNoParam struct{ Option string }
 
-type /* error reason */ (
-	// ConfigIsArrayButHasNoParam is an error reason which indicates that
-	// an option configuration contradicts that the option must be an array
-	// (.IsArray = true) but must have no option parameter (.HasParam = false).
-	ConfigIsArrayButHasNoParam struct{ Option string }
+func (e ConfigIsArrayButHasNoParam) Error() string {
+	return "ConfigIsArrayButHasNoParam"
+}
 
-	// ConfigHasDefaultButHasNoParam is an error reason which indicates that
-	// an option configuration contradicts that the option has default value
-	// (.Default != nil) but must have no option parameter (.HasParam = false).
-	ConfigHasDefaultButHasNoParam struct{ Option string }
+// ConfigHasDefaultButHasNoParam is an error which indicates that an option
+// configuration contradicts that the option has default value
+// (.Default != nil) but must have no option parameter (.HasParam = false).
+type ConfigHasDefaultButHasNoParam struct{ Option string }
 
-	// UnconfiguredOption is an error reason which indicates that there is no
-	// configuration about the input option.
-	UnconfiguredOption struct{ Option string }
+func (e ConfigHasDefaultButHasNoParam) Error() string {
+	return "ConfigHasDefaultButHasNoParam"
+}
 
-	// OptionNeedsParam is an error reason which indicates that an option is
-	// input with no option parameter though its option configuration requires
-	// option parameters (.HasParam = true).
-	OptionNeedsParam struct{ Option string }
+// UnconfiguredOption is an error which indicates that there is no
+// configuration about the input option.
+type UnconfiguredOption struct{ Option string }
 
-	// OptionTakesNoParam is an error reason which indicates that an option is
-	// input with an option parameter though its option configuration does not
-	// accept option parameters (.HasParam = false).
-	OptionTakesNoParam struct{ Option string }
+func (e UnconfiguredOption) Error() string {
+	return "UnconfiguredOption"
+}
 
-	// OptionIsNotArray is an error reason which indicates that an option is
-	// input with an option parameter multiple times though its option
-	// configuration specifies the option is not an array (.IsArray = false).
-	OptionIsNotArray struct{ Option string }
-)
+// OptionNeedsParam is an error which indicates that an option is input with
+// no option parameter though its option configuration requires option
+// parameters (.HasParam = true).
+type OptionNeedsParam struct{ Option string }
+
+func (e OptionNeedsParam) Error() string {
+	return "OptionNeedsParam"
+}
+
+// OptionTakesNoParam is an error which indicates that an option isinput with
+// an option parameter though its option configuration does not accept option
+// parameters (.HasParam = false).
+type OptionTakesNoParam struct{ Option string }
+
+func (e OptionTakesNoParam) Error() string {
+	return "OptionTakesNoParam"
+}
+
+// OptionIsNotArray is an error which indicates that an option is input with
+// an option parameter multiple times though its option configuration specifies
+// the option is not an array (.IsArray = false).
+type OptionIsNotArray struct{ Option string }
+
+func (e OptionIsNotArray) Error() string {
+	return "OptionIsNotArray"
+}
 
 const anyOption = "*"
 
@@ -74,7 +92,7 @@ type OptCfg struct {
 	HasParam bool
 	IsArray  bool
 	Default  []string
-	OnParsed *func([]string) sabi.Err
+	OnParsed *func([]string) error
 	Desc     string
 }
 
@@ -102,17 +120,17 @@ type OptCfg struct {
 // arguments, this function basically returns UnconfiguredOption error.
 // If you want to allow other options, add an option configuration of which
 // Name is "*" (but HasParam and IsArray of this configuration is ignored).
-func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
+func ParseWith(args []string, optCfgs []OptCfg) (Args, error) {
 	hasAnyOpt := false
 	cfgMap := make(map[string]int)
 	for i, cfg := range optCfgs {
 		if !cfg.HasParam {
 			if cfg.IsArray {
-				err := sabi.NewErr(ConfigIsArrayButHasNoParam{Option: cfg.Name})
+				err := ConfigIsArrayButHasNoParam{Option: cfg.Name}
 				return Args{cmdParams: empty}, err
 			}
 			if cfg.Default != nil {
-				err := sabi.NewErr(ConfigHasDefaultButHasNoParam{Option: cfg.Name})
+				err := ConfigHasDefaultButHasNoParam{Option: cfg.Name}
 				return Args{cmdParams: empty}, err
 			}
 		}
@@ -137,15 +155,15 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
 	var cmdParams = make([]string, 0)
 	var optParams = make(map[string][]string)
 
-	var collCmdParams = func(params ...string) sabi.Err {
+	var collCmdParams = func(params ...string) error {
 		cmdParams = append(cmdParams, params...)
-		return sabi.Ok()
+		return nil
 	}
-	var collOptParams = func(opt string, params ...string) sabi.Err {
+	var collOptParams = func(opt string, params ...string) error {
 		i, exists := cfgMap[opt]
 		if !exists {
 			if !hasAnyOpt {
-				return sabi.NewErr(UnconfiguredOption{Option: opt})
+				return UnconfiguredOption{Option: opt}
 			}
 
 			arr := optParams[opt]
@@ -153,17 +171,17 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
 				arr = empty
 			}
 			optParams[opt] = append(arr, params...)
-			return sabi.Ok()
+			return nil
 		}
 
 		cfg := optCfgs[i]
 		if !cfg.HasParam {
 			if len(params) > 0 {
-				return sabi.NewErr(OptionTakesNoParam{Option: cfg.Name})
+				return OptionTakesNoParam{Option: cfg.Name}
 			}
 		} else {
 			if len(params) == 0 {
-				return sabi.NewErr(OptionNeedsParam{Option: cfg.Name})
+				return OptionNeedsParam{Option: cfg.Name}
 			}
 		}
 
@@ -175,16 +193,16 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
 
 		if !cfg.IsArray {
 			if len(arr) > 1 {
-				return sabi.NewErr(OptionIsNotArray{Option: cfg.Name})
+				return OptionIsNotArray{Option: cfg.Name}
 			}
 		}
 
 		optParams[cfg.Name] = arr
-		return sabi.Ok()
+		return nil
 	}
 
 	err := parseArgs(args, collCmdParams, collOptParams, takeParam)
-	if !err.IsOk() {
+	if err != nil {
 		return Args{cmdParams: empty}, err
 	}
 
@@ -196,7 +214,7 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, sabi.Err) {
 		}
 		if cfg.OnParsed != nil {
 			err = (*cfg.OnParsed)(arr)
-			if !err.IsOk() {
+			if err != nil {
 				return Args{cmdParams: empty}, err
 			}
 		}

--- a/parse-with_test.go
+++ b/parse-with_test.go
@@ -12,7 +12,7 @@ func TestParseWith_zeroCfgAndZeroArg(t *testing.T) {
 	osArgs := []string{}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -25,7 +25,7 @@ func TestParseWith_zeroCfgAndOneCommandParam(t *testing.T) {
 	osArgs := []string{"foo-bar"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -38,10 +38,11 @@ func testParseWith_zeroCfgAndOneLongOpt(t *testing.T) {
 	osArgs := []string{"--foo-bar"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "UnconfiguredOption")
+	switch err.(type) {
 	case cliargs.UnconfiguredOption:
-		assert.Equal(t, err.Get("Option"), "foo-bar")
+		assert.Equal(t, err.(cliargs.UnconfiguredOption).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -60,10 +61,11 @@ func TestParseWith_zeroCfgAndOneShortOpt(t *testing.T) {
 	osArgs := []string{"-f"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "UnconfiguredOption")
+	switch err.(type) {
 	case cliargs.UnconfiguredOption:
-		assert.Equal(t, err.Get("Option"), "f")
+		assert.Equal(t, err.(cliargs.UnconfiguredOption).Option, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -84,7 +86,7 @@ func TestParseWith_oneCfgAndZeroOpt(t *testing.T) {
 	osArgs := []string{}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -102,7 +104,7 @@ func TestParseWith_oneCfgAndOneCmdParam(t *testing.T) {
 	osArgs := []string{"foo-bar"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -120,7 +122,7 @@ func TestParseWith_oneCfgAndOneLongOpt(t *testing.T) {
 	osArgs := []string{"--foo-bar"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{})
@@ -138,7 +140,7 @@ func TestParseWith_oneCfgAndOneShortOpt(t *testing.T) {
 	osArgs := []string{"-f"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -156,10 +158,11 @@ func TestParseWith_oneCfgAndOneDifferentLongOpt(t *testing.T) {
 	osArgs := []string{"--boo-far"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "UnconfiguredOption")
+	switch err.(type) {
 	case cliargs.UnconfiguredOption:
-		assert.Equal(t, err.Get("Option"), "boo-far")
+		assert.Equal(t, err.(cliargs.UnconfiguredOption).Option, "boo-far")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -180,10 +183,11 @@ func TestParseWith_oneCfgAndOneDifferentShortOpt(t *testing.T) {
 	osArgs := []string{"-b"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "UnconfiguredOption")
+	switch err.(type) {
 	case cliargs.UnconfiguredOption:
-		assert.Equal(t, err.Get("Option"), "b")
+		assert.Equal(t, err.(cliargs.UnconfiguredOption).Option, "b")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -205,7 +209,7 @@ func TestParseWith_anyOptCfgAndOneDifferentLongOpt(t *testing.T) {
 	osArgs := []string{"--boo-far"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -228,7 +232,7 @@ func TestParseWith_anyOptCfgAndOneDifferentShortOpt(t *testing.T) {
 	osArgs := []string{"-b"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -250,7 +254,7 @@ func TestParseWith_oneCfgHasParamAndOneLongOptHasParam(t *testing.T) {
 	osArgs := []string{"--foo-bar", "ABC"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
@@ -262,7 +266,7 @@ func TestParseWith_oneCfgHasParamAndOneLongOptHasParam(t *testing.T) {
 	osArgs = []string{"--foo-bar=ABC"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
@@ -274,7 +278,7 @@ func TestParseWith_oneCfgHasParamAndOneLongOptHasParam(t *testing.T) {
 	osArgs = []string{"--foo-bar", ""}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{""})
@@ -286,7 +290,7 @@ func TestParseWith_oneCfgHasParamAndOneLongOptHasParam(t *testing.T) {
 	osArgs = []string{"--foo-bar="}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{""})
@@ -304,7 +308,7 @@ func TestParseWith_oneCfgHasParamAndOneShortOptHasParam(t *testing.T) {
 	osArgs := []string{"-f", "ABC"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -316,7 +320,7 @@ func TestParseWith_oneCfgHasParamAndOneShortOptHasParam(t *testing.T) {
 	osArgs = []string{"-f=ABC"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -328,7 +332,7 @@ func TestParseWith_oneCfgHasParamAndOneShortOptHasParam(t *testing.T) {
 	osArgs = []string{"-f", ""}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -340,7 +344,7 @@ func TestParseWith_oneCfgHasParamAndOneShortOptHasParam(t *testing.T) {
 	osArgs = []string{"-f="}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -358,10 +362,11 @@ func TestParseWith_oneCfgHasParamButOneLongOptHasNoParam(t *testing.T) {
 	osArgs := []string{"--foo-bar"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionNeedsParam")
+	switch err.(type) {
 	case cliargs.OptionNeedsParam:
-		assert.Equal(t, err.Get("Option"), "foo-bar")
+		assert.Equal(t, err.(cliargs.OptionNeedsParam).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -382,10 +387,11 @@ func TestParseWith_oneCfgHasParamAndOneShortOptHasNoParam(t *testing.T) {
 	osArgs := []string{"-f"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionNeedsParam")
+	switch err.(type) {
 	case cliargs.OptionNeedsParam:
-		assert.Equal(t, err.Get("Option"), "f")
+		assert.Equal(t, err.(cliargs.OptionNeedsParam).Option, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -406,7 +412,7 @@ func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
 	osArgs := []string{"--foo-bar", "ABC"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{})
@@ -418,10 +424,11 @@ func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
 	osArgs = []string{"--foo-bar=ABC"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionTakesNoParam")
+	switch err.(type) {
 	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.Get("Option"), "foo-bar")
+		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -436,7 +443,7 @@ func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
 	osArgs = []string{"--foo-bar", ""}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{})
@@ -448,10 +455,11 @@ func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
 	osArgs = []string{"--foo-bar="}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionTakesNoParam")
+	switch err.(type) {
 	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.Get("Option"), "foo-bar")
+		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -472,7 +480,7 @@ func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
 	osArgs := []string{"-f", "ABC"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -484,10 +492,11 @@ func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
 	osArgs = []string{"-f=ABC"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionTakesNoParam")
+	switch err.(type) {
 	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.Get("Option"), "f")
+		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -503,7 +512,7 @@ func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
 	osArgs = []string{"-f", ""}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -515,10 +524,11 @@ func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
 	osArgs = []string{"-f="}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionTakesNoParam")
+	switch err.(type) {
 	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.Get("Option"), "f")
+		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -540,10 +550,11 @@ func TestParseWith_oneCfgHasNoParamButIsArray(t *testing.T) {
 	osArgs := []string{"--foo-bar", "ABC"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "ConfigIsArrayButHasNoParam")
+	switch err.(type) {
 	case cliargs.ConfigIsArrayButHasNoParam:
-		assert.Equal(t, err.Get("Option"), "foo-bar")
+		assert.Equal(t, err.(cliargs.ConfigIsArrayButHasNoParam).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -565,7 +576,7 @@ func TestParseWith_oneCfgIsArrayAndOptHasOneParam(t *testing.T) {
 	osArgs := []string{"--foo-bar", "ABC"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
@@ -577,7 +588,7 @@ func TestParseWith_oneCfgIsArrayAndOptHasOneParam(t *testing.T) {
 	osArgs = []string{"--foo-bar", "ABC", "--foo-bar=DEF"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC", "DEF"})
@@ -589,7 +600,7 @@ func TestParseWith_oneCfgIsArrayAndOptHasOneParam(t *testing.T) {
 	osArgs = []string{"-f", "ABC"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -601,7 +612,7 @@ func TestParseWith_oneCfgIsArrayAndOptHasOneParam(t *testing.T) {
 	osArgs = []string{"-f", "ABC", "-f=DEF"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "")
 	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
@@ -623,7 +634,7 @@ func TestParseWith_oneCfgHasAliasesAndArgMatchesName(t *testing.T) {
 	osArgs := []string{"--foo-bar", "ABC"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
@@ -635,7 +646,7 @@ func TestParseWith_oneCfgHasAliasesAndArgMatchesName(t *testing.T) {
 	osArgs = []string{"--foo-bar=ABC"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
@@ -657,7 +668,7 @@ func TestParseWith_oneCfgHasAliasesAndArgMatchesAliases(t *testing.T) {
 	osArgs := []string{"-f", "ABC"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
@@ -669,7 +680,7 @@ func TestParseWith_oneCfgHasAliasesAndArgMatchesAliases(t *testing.T) {
 	osArgs = []string{"-f=ABC"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
@@ -692,7 +703,7 @@ func TestParseWith_combineOptsByNameAndAliases(t *testing.T) {
 	osArgs := []string{"-f", "ABC", "--foo-bar=DEF"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC", "DEF"})
@@ -704,7 +715,7 @@ func TestParseWith_combineOptsByNameAndAliases(t *testing.T) {
 	osArgs = []string{"-f=ABC", "--foo-bar", "DEF"}
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
 	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC", "DEF"})
@@ -727,10 +738,11 @@ func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
 	osArgs := []string{"-f", "ABC", "--foo-bar=DEF"}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionIsNotArray")
+	switch err.(type) {
 	case cliargs.OptionIsNotArray:
-		assert.Equal(t, err.Get("Option"), "foo-bar")
+		assert.Equal(t, err.(cliargs.OptionIsNotArray).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -751,7 +763,7 @@ func TestParseWith_specifyDefault(t *testing.T) {
 	}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.False(t, args.HasOpt("foo"))
 	assert.True(t, args.HasOpt("bar"))
 	assert.True(t, args.HasOpt("baz"))
@@ -771,10 +783,11 @@ func TestParseWith_oneCfgHasNoParamButHasDefault(t *testing.T) {
 	osArgs := []string{}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "ConfigHasDefaultButHasNoParam")
+	switch err.(type) {
 	case cliargs.ConfigHasDefaultButHasNoParam:
-		assert.Equal(t, err.Get("Option"), "foo-bar")
+		assert.Equal(t, err.(cliargs.ConfigHasDefaultButHasNoParam).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -802,7 +815,7 @@ func TestParseWith_multipleArgs(t *testing.T) {
 	}
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("foo-bar"))
 	assert.True(t, args.HasOpt("baz"))
 	assert.True(t, args.HasOpt("X"))

--- a/parse_test.go
+++ b/parse_test.go
@@ -21,7 +21,7 @@ func TestParse_zeroArg(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
@@ -46,7 +46,7 @@ func TestParse_oneNonOptArg(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{"abcd"})
 	assert.False(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
@@ -71,7 +71,7 @@ func TestParse_oneLongOpt(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
@@ -96,7 +96,7 @@ func TestParse_oneLongOptWithParam(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
@@ -121,7 +121,7 @@ func TestParse_oneShortOpt(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{})
 	assert.False(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
@@ -146,7 +146,7 @@ func TestParse_oneShortOptWithParam(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{})
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "123")
@@ -171,7 +171,7 @@ func TestParse_oneArgByMultipleShortOpts(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, len(args.CmdParams()), 0)
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
@@ -182,7 +182,7 @@ func TestParse_oneArgByMultipleShortOpts(t *testing.T) {
 	assert.Equal(t, args.OptParams("s"), []string{})
 	assert.False(t, args.HasOpt("silent"))
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{})
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
@@ -207,7 +207,7 @@ func TestParse_oneArgByMultipleShortOptsWithParam(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{})
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "123")
@@ -232,7 +232,7 @@ func TestParse_longOptNameIncludesHyphenMark(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, len(args.CmdParams()), 0)
 	assert.True(t, args.HasOpt("aaa-bbb-ccc"))
 	assert.Equal(t, args.OptParam("aaa-bbb-ccc"), "123")
@@ -248,7 +248,7 @@ func TestParse_optParamsIncludesEqualMark(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{})
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "b=c")
@@ -273,7 +273,7 @@ func TestParse_optParamsIncludesMarks(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{})
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "1,2-3")
@@ -300,10 +300,11 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionHasInvalidChar")
+	switch err.(type) {
 	case cliargs.OptionHasInvalidChar:
-		assert.Equal(t, err.Get("Option"), "abc%def")
+		assert.Equal(t, err.(cliargs.OptionHasInvalidChar).Option, "abc%def")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -331,10 +332,11 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionHasInvalidChar")
+	switch err.(type) {
 	case cliargs.OptionHasInvalidChar:
-		assert.Equal(t, err.Get("Option"), "1abc")
+		assert.Equal(t, err.(cliargs.OptionHasInvalidChar).Option, "1abc")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -362,9 +364,11 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionHasInvalidChar")
+	switch err.(type) {
 	case cliargs.OptionHasInvalidChar:
-		assert.Equal(t, err.Get("Option"), "-aaa=123")
+		assert.Equal(t, err.(cliargs.OptionHasInvalidChar).Option, "-aaa=123")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -394,10 +398,11 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "OptionHasInvalidChar")
+	switch err.(type) {
 	case cliargs.OptionHasInvalidChar:
-		assert.Equal(t, err.Get("Option"), "@")
+		assert.Equal(t, err.(cliargs.OptionHasInvalidChar).Option, "@")
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -430,7 +435,7 @@ func TestParse_useEndOptMark(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{"-s", "--", "-s@", "xxx"})
 	assert.False(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
@@ -455,7 +460,7 @@ func TestParse_singleHyphen(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.Equal(t, args.CmdParams(), []string{"-"})
 	assert.False(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
@@ -486,7 +491,7 @@ func TestParse_multipleArgs(t *testing.T) {
 
 	args, err := cliargs.Parse()
 
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 	assert.True(t, args.HasOpt("a"))
 	assert.Equal(t, args.OptParam("a"), "")
 	assert.Equal(t, args.OptParams("a"), []string{})

--- a/print-help_test.go
+++ b/print-help_test.go
@@ -11,7 +11,7 @@ func TestMakeHelp_emptyUsage_noOptCfg_emptyWrapOpts(t *testing.T) {
 	wrapOpts := WrapOpts{}
 
 	iter, err := MakeHelp("", optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 
 	line, status := iter.Next()
 	assert.Equal(t, line, "")
@@ -28,7 +28,7 @@ func TestMakeHelp_shortUsage_noOptCfg_emptyWrapOpts(t *testing.T) {
 	wrapOpts := WrapOpts{}
 
 	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 
 	line, status := iter.Next()
 	assert.Equal(t, line, usage)
@@ -48,7 +48,7 @@ func TestMakeHelp_longUsage_noOptCfg_emptyWrapOpts(t *testing.T) {
 	wrapOpts := WrapOpts{}
 
 	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 
 	line, status := iter.Next()
 	assert.Equal(t, line, usage[0:79])
@@ -74,7 +74,7 @@ func TestMakeHelp_longUsage_oneShortOptCfg_emptyWrapOpts(t *testing.T) {
 	wrapOpts := WrapOpts{}
 
 	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 
 	line, status := iter.Next()
 	assert.Equal(t, line, usage[0:79])
@@ -123,7 +123,7 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_emptyWrapOpts(t *testing.T) {
 	wrapOpts := WrapOpts{}
 
 	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 
 	line, status := iter.Next()
 	assert.Equal(t, line, usage[0:79])
@@ -184,7 +184,7 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_largeIndent(t *testing.T) {
 	wrapOpts := WrapOpts{Indent: 20}
 
 	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 
 	line, status := iter.Next()
 	assert.Equal(t, line, usage[0:79])
@@ -245,7 +245,7 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_shortIndent(t *testing.T) {
 	wrapOpts := WrapOpts{Indent: 10}
 
 	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 
 	line, status := iter.Next()
 	assert.Equal(t, line, usage[0:79])
@@ -310,7 +310,7 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_margins(t *testing.T) {
 	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5}
 
 	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 
 	line, status := iter.Next()
 	assert.Equal(t, line, "     "+usage[0:62])
@@ -371,7 +371,7 @@ func TestMakeHelp_optNameIsShortAndOptAliasIsLong(t *testing.T) {
 	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5}
 
 	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 
 	line, status := iter.Next()
 	assert.Equal(t, line, "     "+usage[0:62])
@@ -432,13 +432,14 @@ func TestMakeHelp_marginsAndIndentExceedLineWidth(t *testing.T) {
 	wrapOpts := WrapOpts{MarginLeft: 50, MarginRight: 50, Indent: 10}
 
 	_, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "MarginsAndIndentExceedLineWidth")
+	switch err.(type) {
 	case MarginsAndIndentExceedLineWidth:
-		assert.Equal(t, err.Get("LineWidth"), 80)
-		assert.Equal(t, err.Get("MarginLeft"), 50)
-		assert.Equal(t, err.Get("MarginRight"), 50)
-		assert.Equal(t, err.Get("Indent"), 10)
+		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).LineWidth, 80)
+		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).MarginLeft, 50)
+		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).MarginRight, 50)
+		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).Indent, 10)
 	default:
 		assert.Fail(t, err.Error())
 	}
@@ -468,7 +469,7 @@ func TestPrintHelp(t *testing.T) {
 	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5, Indent: 10}
 
 	err := PrintHelp(usage, optCfgs, wrapOpts)
-	assert.True(t, err.IsOk())
+	assert.Nil(t, err)
 }
 
 func TestPrintHelp_error(t *testing.T) {
@@ -488,13 +489,14 @@ func TestPrintHelp_error(t *testing.T) {
 	wrapOpts := WrapOpts{MarginLeft: 50, MarginRight: 50, Indent: 10}
 
 	err := PrintHelp(usage, optCfgs, wrapOpts)
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "MarginsAndIndentExceedLineWidth")
+	switch err.(type) {
 	case MarginsAndIndentExceedLineWidth:
-		assert.Equal(t, err.Get("LineWidth"), 80)
-		assert.Equal(t, err.Get("MarginLeft"), 50)
-		assert.Equal(t, err.Get("MarginRight"), 50)
-		assert.Equal(t, err.Get("Indent"), 10)
+		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).LineWidth, 80)
+		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).MarginLeft, 50)
+		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).MarginRight, 50)
+		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).Indent, 10)
 	default:
 		assert.Fail(t, err.Error())
 	}


### PR DESCRIPTION
### Changes

This PR drops `sabi` from dependency modules, because dependence on `sabi` was only  using `sabi.Err`.

In addition, errors defined in this package can be used as error reasons of `sabi.Err` in `sabi` application. 