### PR TITLE
fix: removed line break per option

### DIFF
--- a/example_print-help_test.go
+++ b/example_print-help_test.go
@@ -22,16 +22,12 @@ func ExamplePrintHelp() {
 
 	// Output:
 	//      This is the usage section.
-	//
 	//      --foo-bar, -f
 	//                FooBar is a flag.
 	//                This flag is foo bar.
-	//
 	//      --baz, -b
 	//                Baz is a integer.
-	//
 	//      --Qux     Qux is a string.
-	//
 	//      --quux    Quux is a string array.
 	//
 	// err = <nil>
@@ -63,13 +59,9 @@ func ExampleMakeHelp() {
 	// Output:
 	// err = <nil>
 	//      This is the usage section.
-	//
 	//      --foo-bar, -f  FooBar is a flag.
 	//                     This flag is foo bar.
-	//
 	//      --baz, -b      Baz is a integer.
-	//
 	//      --Qux          Qux is a string.
-	//
 	//      --quux         Quux is a string array.
 }

--- a/print-help.go
+++ b/print-help.go
@@ -138,7 +138,6 @@ func MakeHelp(
 
 	texts[0] = usage
 	for i, cfg := range optCfgs {
-		texts[i] += "\n"
 		texts[i+1] = makeOptHelp(texts[i+1], cfg, indent)
 	}
 

--- a/print-help_test.go
+++ b/print-help_test.go
@@ -85,10 +85,6 @@ func TestMakeHelp_longUsage_oneShortOptCfg_emptyWrapOpts(t *testing.T) {
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
 	assert.Equal(t, line, "--foo  This is the description of --foo option.")
 	assert.Equal(t, status, ITER_NO_MORE)
 
@@ -134,15 +130,7 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_emptyWrapOpts(t *testing.T) {
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
 	assert.Equal(t, line, "--foo          This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "")
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
@@ -195,15 +183,7 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_largeIndent(t *testing.T) {
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
 	assert.Equal(t, line, "--foo               This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "")
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
@@ -256,15 +236,7 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_shortIndent(t *testing.T) {
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
 	assert.Equal(t, line, "--foo     This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "")
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
@@ -321,15 +293,7 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_margins(t *testing.T) {
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
 	assert.Equal(t, line, "     --foo          This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "")
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
@@ -382,15 +346,7 @@ func TestMakeHelp_optNameIsShortAndOptAliasIsLong(t *testing.T) {
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
 	assert.Equal(t, line, "     --foo          This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "")
 	assert.Equal(t, status, ITER_HAS_MORE)
 
 	line, status = iter.Next()


### PR DESCRIPTION
This PR removes line break per option, because that line breaks can be achived by adding `\n` at the end of `.Desc` strings.