### PR TITLE
fix: modified the way to calc. widths of option titles in PrintHelp.

### DIFF
--- a/print-help.go
+++ b/print-help.go
@@ -172,12 +172,21 @@ func makeOptTitle(cfg OptCfg) string {
 }
 
 func makeOptHelp(title string, cfg OptCfg, indent int) string {
-	if len(title)+2 > indent {
+	w := titleWidth(title)
+	if w+2 > indent {
 		title += "\n" + strings.Repeat(" ", indent) + cfg.Desc
 	} else {
-		title += strings.Repeat(" ", indent-len(title)) + cfg.Desc
+		title += strings.Repeat(" ", indent-w) + cfg.Desc
 	}
 	return title
+}
+
+func titleWidth(title string) int {
+	w := 0
+	for _, r := range title[:] {
+		w += runeWidth(r)
+	}
+	return w
 }
 
 // PrintHelp is a function which output a help text to stdout.


### PR DESCRIPTION
So far, widths of option titles are calculated with `len`. This is rune count ofthe a title string. However, it will cause the problem when options uses wide/full width characters.

By this PR, widths of option titles will be calculated as sum of rune widths 