### PR TITLE
update!: changed the return values composition of ParseFor

### DIFF
--- a/example_parse-for_test.go
+++ b/example_parse-for_test.go
@@ -7,36 +7,69 @@ import (
 
 func ExampleParseFor() {
 	type MyOptions struct {
-		FooBar bool     `opt:"foo-bar,f"`
-		Baz    int      `opt:"baz,b=99"`
-		Qux    string   `opt:"=XXX"`
-		Quux   []string `opt:"quux=[A,B,C]"`
-		Corge  []int
+		FooBar bool     `opt:"foo-bar,f" optdesc:"FooBar description."`
+		Baz    int      `opt:"baz,b=99" optdesc:"Baz description."`
+		Qux    []string `opt:"qux,q=[A,B,C]" optdesc:"Qux description."`
 	}
 	options := MyOptions{}
 
 	osArgs := []string{
-		"--foo-bar", "c1", "-b", "12", "--Qux", "ABC", "c2",
-		"--Corge", "20", "--Corge=21",
+		"--foo-bar", "c1", "-b", "12", "--qux", "D", "c2", "-q", "E",
 	}
 
-	cmdParams, err := cliargs.ParseFor(osArgs, &options)
+	cmdParams, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 	fmt.Printf("err = %v\n", err)
 	fmt.Printf("cmdParams = %v\n", cmdParams)
+
+	fmt.Printf("optCfgs[0].Name = %v\n", optCfgs[0].Name)
+	fmt.Printf("optCfgs[0].Aliases = %v\n", optCfgs[0].Aliases)
+	fmt.Printf("optCfgs[0].HasParam = %v\n", optCfgs[0].HasParam)
+	fmt.Printf("optCfgs[0].IsArray = %v\n", optCfgs[0].IsArray)
+	fmt.Printf("optCfgs[0].Default = %v\n", optCfgs[0].Default)
+	fmt.Printf("optCfgs[0].Desc = %v\n", optCfgs[0].Desc)
+
+	fmt.Printf("optCfgs[1].Name = %v\n", optCfgs[1].Name)
+	fmt.Printf("optCfgs[1].Aliases = %v\n", optCfgs[1].Aliases)
+	fmt.Printf("optCfgs[1].HasParam = %v\n", optCfgs[1].HasParam)
+	fmt.Printf("optCfgs[1].IsArray = %v\n", optCfgs[1].IsArray)
+	fmt.Printf("optCfgs[1].Default = %v\n", optCfgs[1].Default)
+	fmt.Printf("optCfgs[1].Desc = %v\n", optCfgs[1].Desc)
+
+	fmt.Printf("optCfgs[2].Name = %v\n", optCfgs[2].Name)
+	fmt.Printf("optCfgs[2].Aliases = %v\n", optCfgs[2].Aliases)
+	fmt.Printf("optCfgs[2].HasParam = %v\n", optCfgs[2].HasParam)
+	fmt.Printf("optCfgs[2].IsArray = %v\n", optCfgs[2].IsArray)
+	fmt.Printf("optCfgs[2].Default = %v\n", optCfgs[2].Default)
+	fmt.Printf("optCfgs[2].Desc = %v\n", optCfgs[2].Desc)
+
 	fmt.Printf("options.FooBar = %v\n", options.FooBar)
 	fmt.Printf("options.Baz = %v\n", options.Baz)
 	fmt.Printf("options.Qux = %v\n", options.Qux)
-	fmt.Printf("options.Quux = %v\n", options.Quux)
-	fmt.Printf("options.Corge = %v\n", options.Corge)
 
 	// Output:
 	// err = <nil>
 	// cmdParams = [c1 c2]
+	// optCfgs[0].Name = foo-bar
+	// optCfgs[0].Aliases = [f]
+	// optCfgs[0].HasParam = false
+	// optCfgs[0].IsArray = false
+	// optCfgs[0].Default = []
+	// optCfgs[0].Desc = FooBar description.
+	// optCfgs[1].Name = baz
+	// optCfgs[1].Aliases = [b]
+	// optCfgs[1].HasParam = true
+	// optCfgs[1].IsArray = false
+	// optCfgs[1].Default = [99]
+	// optCfgs[1].Desc = Baz description.
+	// optCfgs[2].Name = qux
+	// optCfgs[2].Aliases = [q]
+	// optCfgs[2].HasParam = true
+	// optCfgs[2].IsArray = true
+	// optCfgs[2].Default = [A B C]
+	// optCfgs[2].Desc = Qux description.
 	// options.FooBar = true
 	// options.Baz = 12
-	// options.Qux = ABC
-	// options.Quux = [A B C]
-	// options.Corge = [20 21]
+	// options.Qux = [D E]
 }
 
 func ExampleMakeOptCfgsFor() {

--- a/parse-for.go
+++ b/parse-for.go
@@ -90,7 +90,7 @@ func (e IllegalOptionType) Error() string {
 // to the option store which is the second parameter of this function.
 // This function divides command line arguments to command parameters and
 // options, then stores the options to the option store, and returns the
-// command parameters.
+// command parameters with the generated option configuratins.
 //
 // The configurations of options are determined by types and struct tags of
 // fields of the option store.
@@ -128,18 +128,18 @@ func (e IllegalOptionType) Error() string {
 // string but an empty array.
 // If you want to specify an array which contains only an empty string, write
 // nothing after "=" mark, like `opt:"name="`.
-func ParseFor(args []string, options any) ([]string, error) {
+func ParseFor(args []string, options any) ([]string, []OptCfg, error) {
 	optCfgs, err := MakeOptCfgsFor(options)
 	if err != nil {
-		return empty, err
+		return empty, optCfgs, err
 	}
 
 	a, err := ParseWith(args, optCfgs)
 	if err != nil {
-		return empty, err
+		return empty, optCfgs, err
 	}
 
-	return a.cmdParams, nil
+	return a.cmdParams, optCfgs, nil
 }
 
 // MakeOptCfgsFor is a function to make a OptCfg array from fields of the

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -12,9 +12,10 @@ func TestParseFor_emptyOptionStoreAndNoArgs(t *testing.T) {
 	type MyOptions struct{}
 	args := []string{}
 	options := MyOptions{}
-	cmdParams, err := cliargs.ParseFor(args, &options)
+	cmdParams, optCfgs, err := cliargs.ParseFor(args, &options)
 	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{})
+	assert.Equal(t, optCfgs, []cliargs.OptCfg{})
 }
 
 func TestParseFor_nonEmptyOptionStoreAndNoArgs(t *testing.T) {
@@ -50,9 +51,10 @@ func TestParseFor_nonEmptyOptionStoreAndNoArgs(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	cmdParams, err := cliargs.ParseFor(args, &options)
+	cmdParams, optCfgs, err := cliargs.ParseFor(args, &options)
 	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{})
+	assert.Equal(t, len(optCfgs), 27)
 	assert.False(t, options.BoolVal)
 	assert.Equal(t, options.IntVal, 0)
 	assert.Equal(t, options.Int8Val, int8(0))
@@ -143,9 +145,10 @@ func TestParseFor_dontOverwriteOptionsIfNoArgs(t *testing.T) {
 	}
 
 	args := []string{}
-	cmdParams, err := cliargs.ParseFor(args, &options)
+	cmdParams, optCfgs, err := cliargs.ParseFor(args, &options)
 	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{})
+	assert.Equal(t, len(optCfgs), 27)
 	assert.True(t, options.BoolVal)
 	assert.Equal(t, options.IntVal, 111)
 	assert.Equal(t, options.Int8Val, int8(22))
@@ -182,10 +185,11 @@ func TestParseFor_optionIsBoolAndArgIsName(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{"--flag", "abc"}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.True(t, options.Flag)
 }
 
@@ -196,10 +200,11 @@ func TestParseFor_optionIsBoolAndArgIsAlias(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{"-f", "abc"}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.True(t, options.Flag)
 }
 
@@ -221,10 +226,11 @@ func TestParseFor_optionsAreIntAndArgsAreNames(t *testing.T) {
 		"--int64-val", "5",
 		"abc",
 	}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntVal, 1)
 	assert.Equal(t, options.Int8Val, int8(2))
 	assert.Equal(t, options.Int16Val, int16(3))
@@ -250,10 +256,11 @@ func TestParseFor_optionsAreIntAndArgsAreAliases(t *testing.T) {
 		"-n", "5",
 		"abc",
 	}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntVal, 1)
 	assert.Equal(t, options.Int8Val, int8(2))
 	assert.Equal(t, options.Int16Val, int16(3))
@@ -279,10 +286,11 @@ func TestParseFor_optionsAreUintAndArgsAreNames(t *testing.T) {
 		"--uint64-val", "5",
 		"abc",
 	}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintVal, uint(1))
 	assert.Equal(t, options.Uint8Val, uint8(2))
 	assert.Equal(t, options.Uint16Val, uint16(3))
@@ -308,10 +316,11 @@ func TestParseFor_optionsAreUintAndArgsAreAliases(t *testing.T) {
 		"-n", "5",
 		"abc",
 	}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintVal, uint(1))
 	assert.Equal(t, options.Uint8Val, uint8(2))
 	assert.Equal(t, options.Uint16Val, uint16(3))
@@ -331,10 +340,11 @@ func TestParseFor_optionsAreFloatAndArgsAreNames(t *testing.T) {
 		"--float64-val", "0.5678",
 		"abc",
 	}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Val, float32(0.1234))
 	assert.Equal(t, options.Float64Val, 0.5678)
 }
@@ -351,10 +361,11 @@ func TestParseFor_optionsAreFloatAndArgsAreAliases(t *testing.T) {
 		"-n", "0.5678",
 		"abc",
 	}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Val, float32(0.1234))
 	assert.Equal(t, options.Float64Val, 0.5678)
 }
@@ -369,10 +380,11 @@ func TestParseFor_optionsAreStringAndArgsAreNames(t *testing.T) {
 		"--string-val", "def",
 		"abc",
 	}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringVal, "def")
 }
 
@@ -386,10 +398,11 @@ func TestParseFor_optionsAreStringAndArgsAreAliases(t *testing.T) {
 		"-s", "def",
 		"abc",
 	}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{"abc"})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringVal, "def")
 }
 
@@ -404,10 +417,11 @@ func TestParseFor_defaultValueIsInt(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntVal, 11)
 	assert.Equal(t, options.Int8Val, int8(22))
 	assert.Equal(t, options.Int16Val, int16(33))
@@ -426,10 +440,11 @@ func TestParseFor_defaultValueIsNegativeInt(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntVal, -11)
 	assert.Equal(t, options.Int8Val, int8(-22))
 	assert.Equal(t, options.Int16Val, int16(-33))
@@ -448,10 +463,11 @@ func TestParseFor_defaultValueIsUint(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintVal, uint(11))
 	assert.Equal(t, options.Uint8Val, uint8(22))
 	assert.Equal(t, options.Uint16Val, uint16(33))
@@ -467,10 +483,11 @@ func TestParseFor_defaultValueIsFloat(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Val, float32(0.123))
 	assert.Equal(t, options.Float64Val, float64(0.456789))
 }
@@ -483,10 +500,11 @@ func TestParseFor_defaultValueIsNegativeFloat(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Val, float32(-0.123))
 	assert.Equal(t, options.Float64Val, float64(-0.456789))
 }
@@ -502,10 +520,11 @@ func TestParseFor_defaultValueIsIntArrayAndSize0(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{})
 	assert.Equal(t, options.Int8Arr, []int8{})
 	assert.Equal(t, options.Int16Arr, []int16{})
@@ -530,10 +549,11 @@ func TestParseFor_overwriteIntArrayWithDefaultValueIfSize0(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{})
 	assert.Equal(t, options.Int8Arr, []int8{})
 	assert.Equal(t, options.Int16Arr, []int16{})
@@ -552,10 +572,11 @@ func TestParseFor_defaultValueIsIntArrayAndSize1(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{1})
 	assert.Equal(t, options.Int8Arr, []int8{2})
 	assert.Equal(t, options.Int16Arr, []int16{3})
@@ -580,10 +601,11 @@ func TestParseFor_overwriteIntArrayWithDefaultValueIfSize1(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{1})
 	assert.Equal(t, options.Int8Arr, []int8{2})
 	assert.Equal(t, options.Int16Arr, []int16{3})
@@ -602,10 +624,11 @@ func TestParseFor_defaultValueIsIntArrayAndSize2(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{1, 2})
 	assert.Equal(t, options.Int8Arr, []int8{2, 3})
 	assert.Equal(t, options.Int16Arr, []int16{3, 4})
@@ -630,10 +653,11 @@ func TestParseFor_overwriteIntArrayWithDefaultValueIfSize2(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{1, 2})
 	assert.Equal(t, options.Int8Arr, []int8{2, 3})
 	assert.Equal(t, options.Int16Arr, []int16{3, 4})
@@ -652,10 +676,11 @@ func TestParseFor_defaultValueIsNegativeIntArray(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{-1, -2})
 	assert.Equal(t, options.Int8Arr, []int8{-2, -3})
 	assert.Equal(t, options.Int16Arr, []int16{-3, -4})
@@ -674,10 +699,11 @@ func TestParseFor_defaultValueIsIntArraySeparatedByColons(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.IntArr, []int{-1, -2})
 	assert.Equal(t, options.Int8Arr, []int8{-2, -3})
 	assert.Equal(t, options.Int16Arr, []int16{-3, -4})
@@ -696,10 +722,11 @@ func TestParseFor_defaultValueIsUintArrayAndSize0(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{})
 	assert.Equal(t, options.Uint8Arr, []uint8{})
 	assert.Equal(t, options.Uint16Arr, []uint16{})
@@ -724,10 +751,11 @@ func TestParseFor_overwriteUintArrayWithDefaultValueIfSize0(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{})
 	assert.Equal(t, options.Uint8Arr, []uint8{})
 	assert.Equal(t, options.Uint16Arr, []uint16{})
@@ -746,10 +774,11 @@ func TestParseFor_defaultValueIsUintArrayAndSize1(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1})
 	assert.Equal(t, options.Uint8Arr, []uint8{2})
 	assert.Equal(t, options.Uint16Arr, []uint16{3})
@@ -774,10 +803,11 @@ func TestParseFor_overwriteUintArrayWithDefaultValueIfSize1(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1})
 	assert.Equal(t, options.Uint8Arr, []uint8{2})
 	assert.Equal(t, options.Uint16Arr, []uint16{3})
@@ -796,10 +826,11 @@ func TestParseFor_defaultValueIsUintArrayAndSize2(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1, 2})
 	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
 	assert.Equal(t, options.Uint16Arr, []uint16{3, 4})
@@ -824,10 +855,11 @@ func TestParseFor_overwriteUintArrayWithDefaultValueIfSize2(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1, 2})
 	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
 	assert.Equal(t, options.Uint16Arr, []uint16{3, 4})
@@ -846,10 +878,11 @@ func TestParseFor_defaultValueIsUintArraySeparatedByColons(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.Equal(t, options.UintArr, []uint{1, 2})
 	assert.Equal(t, options.Uint8Arr, []uint8{2, 3})
 	assert.Equal(t, options.Uint16Arr, []uint16{3, 4})
@@ -865,10 +898,11 @@ func TestParseFor_defaultValueIsFloatArrayAndSize0(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{})
 	assert.Equal(t, options.Float64Arr, []float64{})
 }
@@ -884,10 +918,11 @@ func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize0(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{})
 	assert.Equal(t, options.Float64Arr, []float64{})
 }
@@ -900,10 +935,11 @@ func TestParseFor_defaultValueIsFloatArrayAndSize1(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{0.1})
 	assert.Equal(t, options.Float64Arr, []float64{0.2})
 }
@@ -919,10 +955,11 @@ func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize1(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{0.1})
 	assert.Equal(t, options.Float64Arr, []float64{0.2})
 }
@@ -935,10 +972,11 @@ func TestParseFor_defaultValueIsFloatArrayAndSize2(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
 	assert.Equal(t, options.Float64Arr, []float64{0.3, 0.4})
 }
@@ -954,10 +992,11 @@ func TestParseFor_overwriteFloatArrayWithDefaultValueIfSize2(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{0.1, 0.2})
 	assert.Equal(t, options.Float64Arr, []float64{0.3, 0.4})
 }
@@ -970,10 +1009,11 @@ func TestParseFor_defaultValueIsNegativeFloatArray(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
 	assert.Equal(t, options.Float64Arr, []float64{-0.3, -0.4})
 }
@@ -986,10 +1026,11 @@ func TestParseFor_defaultValueIsFloatArraySeparatedByColons(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 2)
 	assert.Equal(t, options.Float32Arr, []float32{-0.1, -0.2})
 	assert.Equal(t, options.Float64Arr, []float64{-0.3, -0.4})
 }
@@ -1001,10 +1042,11 @@ func TestParseFor_defaultValueIsStringAndSize0(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{})
 }
 
@@ -1017,10 +1059,11 @@ func TestParseFor_overwriteStringArrayWithDefaultValueIfSize0(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{})
 }
 
@@ -1031,10 +1074,11 @@ func TestParseFor_defaultValueIsStringArrayAndSize1(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC"})
 }
 
@@ -1047,10 +1091,11 @@ func TestParseFor_overwriteStringArrayWithDefaultValueIfSize1(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC"})
 }
 
@@ -1061,10 +1106,11 @@ func TestParseFor_defaultValueIsStringArrayAndSize2(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
 }
 
@@ -1077,10 +1123,11 @@ func TestParseFor_overwriteStringArrayWithDefaultValueIfSize2(t *testing.T) {
 	}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
 }
 
@@ -1091,10 +1138,11 @@ func TestParseFor_defaultValueIsStringArraySeparatedByColons(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{"ABC", "DEF"})
 }
 
@@ -1105,10 +1153,11 @@ func TestParseFor_ignoreEmptyDefaultValueIfOptionIsBool(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.False(t, options.BoolVar)
 }
 
@@ -1119,9 +1168,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "FailToParseInt")
 	assert.NotNil(t, errors.Unwrap(err))
@@ -1143,9 +1193,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "FailToParseUint")
 	assert.NotNil(t, errors.Unwrap(err))
@@ -1167,9 +1218,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "FailToParseFloat")
 	assert.NotNil(t, errors.Unwrap(err))
@@ -1191,10 +1243,11 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsString(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringVar, "")
 }
 
@@ -1205,9 +1258,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "FailToParseInt")
 	assert.NotNil(t, errors.Unwrap(err))
@@ -1229,9 +1283,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "FailToParseUint")
 	assert.NotNil(t, errors.Unwrap(err))
@@ -1253,9 +1308,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloatArray(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "FailToParseFloat")
 	assert.NotNil(t, errors.Unwrap(err))
@@ -1277,10 +1333,11 @@ func TestParseFor_optionIsStringArrayAndSetOneEmptyStringByDefaultArray(t *testi
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.Equal(t, options.StringArr, []string{""})
 }
 
@@ -1291,10 +1348,11 @@ func TestParseFor_defaultValueIsIgnoreWhenTypeIsBool(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 1)
 	assert.False(t, options.BoolVar)
 }
 
@@ -1305,9 +1363,10 @@ func TestParseFor_errorIfDefaultValueIsInvalidType(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	params, err := cliargs.ParseFor(args, &options)
+	params, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Equal(t, params, []string{})
+	assert.Equal(t, len(optCfgs), 0) // because of the error
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "IllegalOptionType")
 	switch err.(type) {
@@ -1334,10 +1393,11 @@ func TestParseFor_multipleOptsAndMultipleArgs(t *testing.T) {
 		"--Corge", "20", "--Corge=21",
 	}
 
-	cmdParams, err := cliargs.ParseFor(args, &options)
+	cmdParams, optCfgs, err := cliargs.ParseFor(args, &options)
 
 	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{"c1", "c2"})
+	assert.Equal(t, len(optCfgs), 5)
 	assert.True(t, options.FooBar)
 	assert.Equal(t, options.Baz, 12)
 	assert.Equal(t, options.Qux, "ABC")
@@ -1428,9 +1488,10 @@ func TestParseFor_emptyArrayOfDefaultValueWithNotCommaSeparator(t *testing.T) {
 	options := MyOptions{}
 
 	args := []string{}
-	cmdParams, err := cliargs.ParseFor(args, &options)
+	cmdParams, optCfgs, err := cliargs.ParseFor(args, &options)
 	assert.Nil(t, err)
 	assert.Equal(t, cmdParams, []string{})
+	assert.Equal(t, len(optCfgs), 4)
 	assert.Equal(t, options.Foo, []int{})
 	assert.Equal(t, options.Bar, []uint{})
 	assert.Equal(t, options.Baz, []float64{})


### PR DESCRIPTION
This PR makes enable to get option configurations from `ParseFor` function, because if `ParseFor` returns an error which is due to command line arguments, `MakeOptCfgsFor` function had to be called to get option configurations before calling `PrintHelp` function, until now.

By this PR, `PrintHelp` function will be able to call with the option configurations returned from `ParseFor`.