### PR TITLE
new: added a struct tag `optparam` for .AtParam of OptCfg with ParseFor

### DIFF
--- a/example_parse-for_test.go
+++ b/example_parse-for_test.go
@@ -8,8 +8,8 @@ import (
 func ExampleParseFor() {
 	type MyOptions struct {
 		FooBar bool     `opt:"foo-bar,f" optdesc:"FooBar description."`
-		Baz    int      `opt:"baz,b=99" optdesc:"Baz description."`
-		Qux    []string `opt:"qux,q=[A,B,C]" optdesc:"Qux description."`
+		Baz    int      `opt:"baz,b=99" optdesc:"Baz description." optparam:"<num>"`
+		Qux    []string `opt:"qux,q=[A,B,C]" optdesc:"Qux description." optparam:"<text>"`
 	}
 	options := MyOptions{}
 
@@ -34,6 +34,7 @@ func ExampleParseFor() {
 	fmt.Printf("optCfgs[1].IsArray = %v\n", optCfgs[1].IsArray)
 	fmt.Printf("optCfgs[1].Default = %v\n", optCfgs[1].Default)
 	fmt.Printf("optCfgs[1].Desc = %v\n", optCfgs[1].Desc)
+	fmt.Printf("optCfgs[1].AtParam = %v\n", optCfgs[1].AtParam)
 
 	fmt.Printf("optCfgs[2].Name = %v\n", optCfgs[2].Name)
 	fmt.Printf("optCfgs[2].Aliases = %v\n", optCfgs[2].Aliases)
@@ -41,6 +42,7 @@ func ExampleParseFor() {
 	fmt.Printf("optCfgs[2].IsArray = %v\n", optCfgs[2].IsArray)
 	fmt.Printf("optCfgs[2].Default = %v\n", optCfgs[2].Default)
 	fmt.Printf("optCfgs[2].Desc = %v\n", optCfgs[2].Desc)
+	fmt.Printf("optCfgs[2].AtParam = %v\n", optCfgs[2].AtParam)
 
 	fmt.Printf("options.FooBar = %v\n", options.FooBar)
 	fmt.Printf("options.Baz = %v\n", options.Baz)
@@ -61,12 +63,14 @@ func ExampleParseFor() {
 	// optCfgs[1].IsArray = false
 	// optCfgs[1].Default = [99]
 	// optCfgs[1].Desc = Baz description.
+	// optCfgs[1].AtParam = <num>
 	// optCfgs[2].Name = qux
 	// optCfgs[2].Aliases = [q]
 	// optCfgs[2].HasParam = true
 	// optCfgs[2].IsArray = true
 	// optCfgs[2].Default = [A B C]
 	// optCfgs[2].Desc = Qux description.
+	// optCfgs[2].AtParam = <text>
 	// options.FooBar = true
 	// options.Baz = 12
 	// options.Qux = [D E]
@@ -75,9 +79,9 @@ func ExampleParseFor() {
 func ExampleMakeOptCfgsFor() {
 	type MyOptions struct {
 		FooBar bool     `opt:"foo-bar,f" optdesc:"FooBar description"`
-		Baz    int      `opt:"baz,b=99" optdesc:"Baz description"`
-		Qux    string   `opt:"=XXX" optdesc:"Qux description"`
-		Quux   []string `opt:"quux=[A,B,C]" optdesc:"Quux description"`
+		Baz    int      `opt:"baz,b=99" optdesc:"Baz description" optparam:"<number>"`
+		Qux    string   `opt:"=XXX" optdesc:"Qux description" optparam:"<string>"`
+		Quux   []string `opt:"quux=[A,B,C]" optdesc:"Quux description" optparam:"<array elem>"`
 		Corge  []int
 	}
 	options := MyOptions{}
@@ -99,6 +103,7 @@ func ExampleMakeOptCfgsFor() {
 	fmt.Printf("optCfgs[1].IsArray = %v\n", optCfgs[1].IsArray)
 	fmt.Printf("optCfgs[1].Default = %v\n", optCfgs[1].Default)
 	fmt.Printf("optCfgs[1].Desc = %v\n", optCfgs[1].Desc)
+	fmt.Printf("optCfgs[1].AtParam = %v\n", optCfgs[1].AtParam)
 	fmt.Println()
 	fmt.Printf("optCfgs[2].Name = %v\n", optCfgs[2].Name)
 	fmt.Printf("optCfgs[2].Aliases = %v\n", optCfgs[2].Aliases)
@@ -106,6 +111,7 @@ func ExampleMakeOptCfgsFor() {
 	fmt.Printf("optCfgs[2].IsArray = %v\n", optCfgs[2].IsArray)
 	fmt.Printf("optCfgs[2].Default = %v\n", optCfgs[2].Default)
 	fmt.Printf("optCfgs[2].Desc = %v\n", optCfgs[2].Desc)
+	fmt.Printf("optCfgs[2].AtParam = %v\n", optCfgs[2].AtParam)
 	fmt.Println()
 	fmt.Printf("optCfgs[3].Name = %v\n", optCfgs[3].Name)
 	fmt.Printf("optCfgs[3].Aliases = %v\n", optCfgs[3].Aliases)
@@ -113,6 +119,7 @@ func ExampleMakeOptCfgsFor() {
 	fmt.Printf("optCfgs[3].IsArray = %v\n", optCfgs[3].IsArray)
 	fmt.Printf("optCfgs[3].Default = %v\n", optCfgs[3].Default)
 	fmt.Printf("optCfgs[3].Desc = %v\n", optCfgs[3].Desc)
+	fmt.Printf("optCfgs[3].AtParam = %v\n", optCfgs[3].AtParam)
 	fmt.Println()
 	fmt.Printf("optCfgs[4].Name = %v\n", optCfgs[4].Name)
 	fmt.Printf("optCfgs[4].Aliases = %v\n", optCfgs[4].Aliases)
@@ -138,6 +145,7 @@ func ExampleMakeOptCfgsFor() {
 	// optCfgs[1].IsArray = false
 	// optCfgs[1].Default = [99]
 	// optCfgs[1].Desc = Baz description
+	// optCfgs[1].AtParam = <number>
 	//
 	// optCfgs[2].Name = Qux
 	// optCfgs[2].Aliases = []
@@ -145,6 +153,7 @@ func ExampleMakeOptCfgsFor() {
 	// optCfgs[2].IsArray = false
 	// optCfgs[2].Default = [XXX]
 	// optCfgs[2].Desc = Qux description
+	// optCfgs[2].AtParam = <string>
 	//
 	// optCfgs[3].Name = quux
 	// optCfgs[3].Aliases = []
@@ -152,6 +161,7 @@ func ExampleMakeOptCfgsFor() {
 	// optCfgs[3].IsArray = true
 	// optCfgs[3].Default = [A B C]
 	// optCfgs[3].Desc = Quux description
+	// optCfgs[3].AtParam = <array elem>
 	//
 	// optCfgs[4].Name = Corge
 	// optCfgs[4].Aliases = []

--- a/parse-for.go
+++ b/parse-for.go
@@ -220,6 +220,11 @@ func newOptCfg(fld reflect.StructField) OptCfg {
 		}
 	}
 
+	var atparam string
+	if hasParam {
+		atparam = fld.Tag.Get("optparam")
+	}
+
 	desc := fld.Tag.Get("optdesc")
 
 	return OptCfg{
@@ -229,6 +234,7 @@ func newOptCfg(fld reflect.StructField) OptCfg {
 		IsArray:  isArray,
 		Default:  defaults,
 		Desc:     desc,
+		AtParam:  atparam,
 	}
 }
 

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -1517,6 +1517,25 @@ func TestMakeOptCfgsFor_optionDescriptions(t *testing.T) {
 	assert.Equal(t, optCfgs[4].Desc, "")
 }
 
+func TestMakeOptCfgsFor_optionParam(t *testing.T) {
+	type MyOptions struct {
+		FooBar bool     `opt:"foo-bar,f" optparam:"aaa"`
+		Baz    int      `opt:"baz,b=99" optparam:"bbb"`
+		Qux    string   `opt:"=XXX" optparam:"ccc"`
+		Quux   []string `opt:"quux=/[A/B/C]" optparam:"ddd (multiple)"`
+		Corge  []int
+	}
+	options := MyOptions{}
+
+	optCfgs, err0 := cliargs.MakeOptCfgsFor(&options)
+	assert.Nil(t, err0)
+	assert.Equal(t, optCfgs[0].AtParam, "")
+	assert.Equal(t, optCfgs[1].AtParam, "bbb")
+	assert.Equal(t, optCfgs[2].AtParam, "ccc")
+	assert.Equal(t, optCfgs[3].AtParam, "ddd (multiple)")
+	assert.Equal(t, optCfgs[4].AtParam, "")
+}
+
 func TestParseFor_optCfgHasUnsupportedType(t *testing.T) {
 	type A struct{ Name string }
 	type MyOptions struct {

--- a/print-help.go
+++ b/print-help.go
@@ -91,9 +91,10 @@ func (iter *HelpIter) Next() (string, IterStatus) {
 //
 // A help text consists of an usage section and options section, and options
 // section consists of title parts and description parts.
-// A title part enumerates a option name and aliases, and its description
-// follows the title with an indent, specified in WrapOpts,  in a description
-// part.
+// On a title part, a option name, aliases, and a .AtParam field of OptCfg are
+// enumerated.
+// On a description part, a .Desc field of OptCfg is put and it follows a title
+// part with an indent, specified in WrapOpts,
 //
 // On the both sides of a help text, left margin and right margin of which size
 // are specified in WrapOpts can be put.


### PR DESCRIPTION
This PR adds a struct tag `optparam` which enables to set `.AtParam` field value of a `OptCfg` with `ParseFor` function.