### PR TITLE
fix: made error.Error() output error fields

### DIFF
--- a/parse-for.go
+++ b/parse-for.go
@@ -5,6 +5,7 @@
 package cliargs
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -16,7 +17,7 @@ import (
 type OptionStoreIsNotChangeable struct{}
 
 func (e OptionStoreIsNotChangeable) Error() string {
-	return "OptionStoreIsNotChangeable"
+	return "OptionStoreIsNotChangeable{}"
 }
 
 // FailToParseInt is an error reaason which indicates that an option
@@ -30,7 +31,9 @@ type FailToParseInt struct {
 }
 
 func (e FailToParseInt) Error() string {
-	return "FailToParseInt"
+	return fmt.Sprintf("FailToParseInt{"+
+		"Option:%s,Field:%s,Input:%s,BitSize:%d,cause:%s}",
+		e.Option, e.Field, e.Input, e.BitSize, e.cause.Error())
 }
 
 func (e FailToParseInt) Unwrap() error {
@@ -48,7 +51,9 @@ type FailToParseUint struct {
 }
 
 func (e FailToParseUint) Error() string {
-	return "FailToParseUint"
+	return fmt.Sprintf("FailToParseUint{"+
+		"Option:%s,Field:%s,Input:%s,BitSize:%d,cause:%s}",
+		e.Option, e.Field, e.Input, e.BitSize, e.cause.Error())
 }
 
 func (e FailToParseUint) Unwrap() error {
@@ -66,7 +71,9 @@ type FailToParseFloat struct {
 }
 
 func (e FailToParseFloat) Error() string {
-	return "FailToParseFloat"
+	return fmt.Sprintf("FailToParseFloat{"+
+		"Option:%s,Field:%s,Input:%s,BitSize:%d,cause:%s}",
+		e.Option, e.Field, e.Input, e.BitSize, e.cause.Error())
 }
 
 func (e FailToParseFloat) Unwrap() error {
@@ -83,7 +90,9 @@ type IllegalOptionType struct {
 }
 
 func (e IllegalOptionType) Error() string {
-	return "IllegalOptionType"
+	return fmt.Sprintf("IllegalOptionType{"+
+		"Option:%s,Field:%s,Type:%s}",
+		e.Option, e.Field, e.Type.String())
 }
 
 // ParseFor is a function to parse command line arguments and set their values

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -1173,7 +1173,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsInt(t *testing.T) {
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "FailToParseInt")
+	assert.Equal(t, err.Error(), "FailToParseInt{"+
+		"Option:int-var,Field:IntVar,Input:,BitSize:64,"+
+		"cause:strconv.ParseInt: parsing \"\": invalid syntax}",
+	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
 	case cliargs.FailToParseInt:
@@ -1198,7 +1201,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUint(t *testing.T) {
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "FailToParseUint")
+	assert.Equal(t, err.Error(), "FailToParseUint{"+
+		"Option:uint-var,Field:UintVar,Input:,BitSize:64,"+
+		"cause:strconv.ParseUint: parsing \"\": invalid syntax}",
+	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
 	case cliargs.FailToParseUint:
@@ -1223,7 +1229,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloat(t *testing.T) {
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "FailToParseFloat")
+	assert.Equal(t, err.Error(), "FailToParseFloat{"+
+		"Option:float-var,Field:Float64Var,Input:,BitSize:64,"+
+		"cause:strconv.ParseFloat: parsing \"\": invalid syntax}",
+	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
 	case cliargs.FailToParseFloat:
@@ -1263,7 +1272,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsIntArray(t *testing.T) {
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "FailToParseInt")
+	assert.Equal(t, err.Error(), "FailToParseInt{"+
+		"Option:int-arr,Field:IntArr,Input:,BitSize:64,"+
+		"cause:strconv.ParseInt: parsing \"\": invalid syntax}",
+	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
 	case cliargs.FailToParseInt:
@@ -1288,7 +1300,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsUintArray(t *testing.T) {
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "FailToParseUint")
+	assert.Equal(t, err.Error(), "FailToParseUint{"+
+		"Option:uint-arr,Field:UintArr,Input:,BitSize:64,"+
+		"cause:strconv.ParseUint: parsing \"\": invalid syntax}",
+	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
 	case cliargs.FailToParseUint:
@@ -1313,7 +1328,10 @@ func TestParseFor_errorEmptyDefaultValueIfOptionIsFloatArray(t *testing.T) {
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, len(optCfgs), 1)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "FailToParseFloat")
+	assert.Equal(t, err.Error(), "FailToParseFloat{"+
+		"Option:float-arr,Field:Float64Arr,Input:,BitSize:64,"+
+		"cause:strconv.ParseFloat: parsing \"\": invalid syntax}",
+	)
 	assert.NotNil(t, errors.Unwrap(err))
 	switch err.(type) {
 	case cliargs.FailToParseFloat:
@@ -1368,9 +1386,12 @@ func TestParseFor_errorIfDefaultValueIsInvalidType(t *testing.T) {
 	assert.Equal(t, params, []string{})
 	assert.Equal(t, len(optCfgs), 0) // because of the error
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "IllegalOptionType")
+	assert.Equal(t, err.Error(), "IllegalOptionType{"+
+		"Option:BoolArr,Field:BoolArr,Type:[]bool}",
+	)
 	switch err.(type) {
 	case cliargs.IllegalOptionType:
+		assert.Equal(t, err.(cliargs.IllegalOptionType).Option, "BoolArr")
 		assert.Equal(t, err.(cliargs.IllegalOptionType).Field, "BoolArr")
 		assert.Equal(t, err.(cliargs.IllegalOptionType).Type, reflect.TypeOf(options.BoolArr))
 	default:
@@ -1546,7 +1567,9 @@ func TestParseFor_optCfgHasUnsupportedType(t *testing.T) {
 
 	_, err := cliargs.MakeOptCfgsFor(&options)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "IllegalOptionType")
+	assert.Equal(t, err.Error(), "IllegalOptionType{"+
+		"Option:foo-bar,Field:FooBar,Type:cliargs_test.A}",
+	)
 	switch err.(type) {
 	case cliargs.IllegalOptionType:
 		assert.Equal(t, err.(cliargs.IllegalOptionType).Option, "foo-bar")
@@ -1570,7 +1593,7 @@ func TestParseFor_argIsNotPointer(t *testing.T) {
 	_, err := cliargs.MakeOptCfgsFor(options)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionStoreIsNotChangeable")
+	assert.Equal(t, err.Error(), "OptionStoreIsNotChangeable{}")
 	switch err.(type) {
 	case cliargs.OptionStoreIsNotChangeable:
 	default:

--- a/parse-with.go
+++ b/parse-with.go
@@ -4,13 +4,17 @@
 
 package cliargs
 
+import (
+	"fmt"
+)
+
 // ConfigIsArrayButHasNoParam is an error which indicates that an option
 // configuration contradicts that the option must be an array
 // (.IsArray = true) but must have no option parameter (.HasParam = false).
 type ConfigIsArrayButHasNoParam struct{ Option string }
 
 func (e ConfigIsArrayButHasNoParam) Error() string {
-	return "ConfigIsArrayButHasNoParam"
+	return fmt.Sprintf("ConfigIsArrayButHasNoParam{Option:%s}", e.Option)
 }
 
 // ConfigHasDefaultButHasNoParam is an error which indicates that an option
@@ -19,7 +23,7 @@ func (e ConfigIsArrayButHasNoParam) Error() string {
 type ConfigHasDefaultButHasNoParam struct{ Option string }
 
 func (e ConfigHasDefaultButHasNoParam) Error() string {
-	return "ConfigHasDefaultButHasNoParam"
+	return fmt.Sprintf("ConfigHasDefaultButHasNoParam{Option:%s}", e.Option)
 }
 
 // UnconfiguredOption is an error which indicates that there is no
@@ -27,7 +31,7 @@ func (e ConfigHasDefaultButHasNoParam) Error() string {
 type UnconfiguredOption struct{ Option string }
 
 func (e UnconfiguredOption) Error() string {
-	return "UnconfiguredOption"
+	return fmt.Sprintf("UnconfiguredOption{Option:%s}", e.Option)
 }
 
 // OptionNeedsParam is an error which indicates that an option is input with
@@ -36,7 +40,7 @@ func (e UnconfiguredOption) Error() string {
 type OptionNeedsParam struct{ Option string }
 
 func (e OptionNeedsParam) Error() string {
-	return "OptionNeedsParam"
+	return fmt.Sprintf("OptionNeedsParam{Option:%s}", e.Option)
 }
 
 // OptionTakesNoParam is an error which indicates that an option isinput with
@@ -45,7 +49,7 @@ func (e OptionNeedsParam) Error() string {
 type OptionTakesNoParam struct{ Option string }
 
 func (e OptionTakesNoParam) Error() string {
-	return "OptionTakesNoParam"
+	return fmt.Sprintf("OptionTakesNoParam{Option:%s}", e.Option)
 }
 
 // OptionIsNotArray is an error which indicates that an option is input with
@@ -54,7 +58,7 @@ func (e OptionTakesNoParam) Error() string {
 type OptionIsNotArray struct{ Option string }
 
 func (e OptionIsNotArray) Error() string {
-	return "OptionIsNotArray"
+	return fmt.Sprintf("OptionIsNotArray{Option:%s}", e.Option)
 }
 
 const anyOption = "*"

--- a/parse-with_test.go
+++ b/parse-with_test.go
@@ -62,7 +62,7 @@ func TestParseWith_zeroCfgAndOneShortOpt(t *testing.T) {
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "UnconfiguredOption")
+	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:f}")
 	switch err.(type) {
 	case cliargs.UnconfiguredOption:
 		assert.Equal(t, err.(cliargs.UnconfiguredOption).Option, "f")
@@ -159,7 +159,7 @@ func TestParseWith_oneCfgAndOneDifferentLongOpt(t *testing.T) {
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "UnconfiguredOption")
+	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:boo-far}")
 	switch err.(type) {
 	case cliargs.UnconfiguredOption:
 		assert.Equal(t, err.(cliargs.UnconfiguredOption).Option, "boo-far")
@@ -184,7 +184,7 @@ func TestParseWith_oneCfgAndOneDifferentShortOpt(t *testing.T) {
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "UnconfiguredOption")
+	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:b}")
 	switch err.(type) {
 	case cliargs.UnconfiguredOption:
 		assert.Equal(t, err.(cliargs.UnconfiguredOption).Option, "b")
@@ -363,7 +363,7 @@ func TestParseWith_oneCfgHasParamButOneLongOptHasNoParam(t *testing.T) {
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionNeedsParam")
+	assert.Equal(t, err.Error(), "OptionNeedsParam{Option:foo-bar}")
 	switch err.(type) {
 	case cliargs.OptionNeedsParam:
 		assert.Equal(t, err.(cliargs.OptionNeedsParam).Option, "foo-bar")
@@ -388,7 +388,7 @@ func TestParseWith_oneCfgHasParamAndOneShortOptHasNoParam(t *testing.T) {
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionNeedsParam")
+	assert.Equal(t, err.Error(), "OptionNeedsParam{Option:f}")
 	switch err.(type) {
 	case cliargs.OptionNeedsParam:
 		assert.Equal(t, err.(cliargs.OptionNeedsParam).Option, "f")
@@ -425,7 +425,7 @@ func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionTakesNoParam")
+	assert.Equal(t, err.Error(), "OptionTakesNoParam{Option:foo-bar}")
 	switch err.(type) {
 	case cliargs.OptionTakesNoParam:
 		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "foo-bar")
@@ -456,7 +456,7 @@ func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionTakesNoParam")
+	assert.Equal(t, err.Error(), "OptionTakesNoParam{Option:foo-bar}")
 	switch err.(type) {
 	case cliargs.OptionTakesNoParam:
 		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "foo-bar")
@@ -493,7 +493,7 @@ func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionTakesNoParam")
+	assert.Equal(t, err.Error(), "OptionTakesNoParam{Option:f}")
 	switch err.(type) {
 	case cliargs.OptionTakesNoParam:
 		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "f")
@@ -525,7 +525,7 @@ func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
 
 	args, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionTakesNoParam")
+	assert.Equal(t, err.Error(), "OptionTakesNoParam{Option:f}")
 	switch err.(type) {
 	case cliargs.OptionTakesNoParam:
 		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "f")
@@ -551,7 +551,7 @@ func TestParseWith_oneCfgHasNoParamButIsArray(t *testing.T) {
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "ConfigIsArrayButHasNoParam")
+	assert.Equal(t, err.Error(), "ConfigIsArrayButHasNoParam{Option:foo-bar}")
 	switch err.(type) {
 	case cliargs.ConfigIsArrayButHasNoParam:
 		assert.Equal(t, err.(cliargs.ConfigIsArrayButHasNoParam).Option, "foo-bar")
@@ -739,7 +739,7 @@ func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionIsNotArray")
+	assert.Equal(t, err.Error(), "OptionIsNotArray{Option:foo-bar}")
 	switch err.(type) {
 	case cliargs.OptionIsNotArray:
 		assert.Equal(t, err.(cliargs.OptionIsNotArray).Option, "foo-bar")
@@ -784,7 +784,7 @@ func TestParseWith_oneCfgHasNoParamButHasDefault(t *testing.T) {
 
 	args, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "ConfigHasDefaultButHasNoParam")
+	assert.Equal(t, err.Error(), "ConfigHasDefaultButHasNoParam{Option:foo-bar}")
 	switch err.(type) {
 	case cliargs.ConfigHasDefaultButHasNoParam:
 		assert.Equal(t, err.(cliargs.ConfigHasDefaultButHasNoParam).Option, "foo-bar")

--- a/parse.go
+++ b/parse.go
@@ -5,6 +5,7 @@
 package cliargs
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"unicode"
@@ -15,7 +16,7 @@ import (
 type OptionHasInvalidChar struct{ Option string }
 
 func (e OptionHasInvalidChar) Error() string {
-	return "OptionHasInvalidChar"
+	return fmt.Sprintf("OptionHasInvalidChar{Option:%s}", e.Option)
 }
 
 var (

--- a/parse_test.go
+++ b/parse_test.go
@@ -301,7 +301,7 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 	args, err := cliargs.Parse()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionHasInvalidChar")
+	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:abc%def}")
 	switch err.(type) {
 	case cliargs.OptionHasInvalidChar:
 		assert.Equal(t, err.(cliargs.OptionHasInvalidChar).Option, "abc%def")
@@ -333,7 +333,7 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 	args, err := cliargs.Parse()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionHasInvalidChar")
+	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:1abc}")
 	switch err.(type) {
 	case cliargs.OptionHasInvalidChar:
 		assert.Equal(t, err.(cliargs.OptionHasInvalidChar).Option, "1abc")
@@ -365,7 +365,7 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 	args, err := cliargs.Parse()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionHasInvalidChar")
+	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:-aaa=123}")
 	switch err.(type) {
 	case cliargs.OptionHasInvalidChar:
 		assert.Equal(t, err.(cliargs.OptionHasInvalidChar).Option, "-aaa=123")
@@ -399,7 +399,7 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 	args, err := cliargs.Parse()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionHasInvalidChar")
+	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:@}")
 	switch err.(type) {
 	case cliargs.OptionHasInvalidChar:
 		assert.Equal(t, err.(cliargs.OptionHasInvalidChar).Option, "@")

--- a/print-help.go
+++ b/print-help.go
@@ -19,7 +19,9 @@ type MarginsAndIndentExceedLineWidth struct {
 }
 
 func (e MarginsAndIndentExceedLineWidth) Error() string {
-	return "MarginsAndIndentExceedLineWidth"
+	return fmt.Sprintf("MarginsAndIndentExceedLineWidth{"+
+		"LineWidth:%d,MarginLeft:%d,MarginRight:%d,Indent:%d}",
+		e.LineWidth, e.MarginLeft, e.MarginRight, e.Indent)
 }
 
 // WrapOpts is a struct type which holds options for wrapping texts.

--- a/print-help_test.go
+++ b/print-help_test.go
@@ -389,7 +389,8 @@ func TestMakeHelp_marginsAndIndentExceedLineWidth(t *testing.T) {
 
 	_, err := MakeHelp(usage, optCfgs, wrapOpts)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "MarginsAndIndentExceedLineWidth")
+	assert.Equal(t, err.Error(), "MarginsAndIndentExceedLineWidth{"+
+		"LineWidth:80,MarginLeft:50,MarginRight:50,Indent:10}")
 	switch err.(type) {
 	case MarginsAndIndentExceedLineWidth:
 		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).LineWidth, 80)
@@ -515,7 +516,8 @@ func TestPrintHelp_error(t *testing.T) {
 
 	err := PrintHelp(usage, optCfgs, wrapOpts)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "MarginsAndIndentExceedLineWidth")
+	assert.Equal(t, err.Error(), "MarginsAndIndentExceedLineWidth{"+
+		"LineWidth:80,MarginLeft:50,MarginRight:50,Indent:10}")
 	switch err.(type) {
 	case MarginsAndIndentExceedLineWidth:
 		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).LineWidth, 80)
@@ -530,42 +532,42 @@ func TestPrintHelp_error(t *testing.T) {
 func TestMakeHelp_optCfgsIncludesAnyOption(t *testing.T) {
 	usage := "abcdefg"
 	optCfgs := []OptCfg{
-		OptCfg{Name:"foo", Desc:"description of foo."},
-		OptCfg{Name:"bar-baz", Desc:"description of bar-baz."},
-		OptCfg{Name:"*", Desc:"description of *."},
-		OptCfg{Name:"qux", Desc:"description of qux."},
-  }
+		OptCfg{Name: "foo", Desc: "description of foo."},
+		OptCfg{Name: "bar-baz", Desc: "description of bar-baz."},
+		OptCfg{Name: "*", Desc: "description of *."},
+		OptCfg{Name: "qux", Desc: "description of qux."},
+	}
 	wrapOpts := WrapOpts{}
 
-  iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-  assert.Nil(t, err)
-  text, status := iter.Next()
-  assert.Equal(t, status, ITER_HAS_MORE)
-  assert.Equal(t, text, usage)
-  text, status = iter.Next()
-  assert.Equal(t, status, ITER_HAS_MORE)
-  assert.Equal(t, text, "--foo      description of foo.")
-  text, status = iter.Next()
-  assert.Equal(t, status, ITER_HAS_MORE)
-  assert.Equal(t, text, "--bar-baz  description of bar-baz.")
-  text, status = iter.Next()
-  assert.Equal(t, status, ITER_NO_MORE)
-  assert.Equal(t, text, "--qux      description of qux.")
-  text, status = iter.Next()
-  assert.Equal(t, status, ITER_NO_MORE)
-  assert.Equal(t, text, "")
+	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
+	assert.Nil(t, err)
+	text, status := iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, text, usage)
+	text, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, text, "--foo      description of foo.")
+	text, status = iter.Next()
+	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, text, "--bar-baz  description of bar-baz.")
+	text, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, text, "--qux      description of qux.")
+	text, status = iter.Next()
+	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, text, "")
 }
 
 func TestPrintHelp_optCfgsIncludesAnyOption(t *testing.T) {
 	usage := "abcdefg"
 	optCfgs := []OptCfg{
-		OptCfg{Name:"foo", Desc:"description of foo."},
-		OptCfg{Name:"bar-baz", Desc:"description of bar-baz."},
-		OptCfg{Name:"*", Desc:"description of *."},
-		OptCfg{Name:"qux", Desc:"description of qux."},
-  }
-	wrapOpts := WrapOpts{MarginLeft:5}
+		OptCfg{Name: "foo", Desc: "description of foo."},
+		OptCfg{Name: "bar-baz", Desc: "description of bar-baz."},
+		OptCfg{Name: "*", Desc: "description of *."},
+		OptCfg{Name: "qux", Desc: "description of qux."},
+	}
+	wrapOpts := WrapOpts{MarginLeft: 5}
 
-  err := PrintHelp(usage, optCfgs, wrapOpts)
-  assert.Nil(t, err)
+	err := PrintHelp(usage, optCfgs, wrapOpts)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
So far, `error.Error()` of errors defined in this package output only their type name.

This PR made them output also their fields.