### PR TITLE
update!: changed APIs

### DIFF
--- a/example_parse-for_test.go
+++ b/example_parse-for_test.go
@@ -7,42 +7,44 @@ import (
 
 func ExampleParseFor() {
 	type MyOptions struct {
-		FooBar bool     `opt:"foo-bar,f" optdesc:"FooBar description."`
-		Baz    int      `opt:"baz,b=99" optdesc:"Baz description." optparam:"<num>"`
-		Qux    []string `opt:"qux,q=[A,B,C]" optdesc:"Qux description." optparam:"<text>"`
+		FooBar bool     `optcfg:"foo-bar,f" optdesc:"FooBar description."`
+		Baz    int      `optcfg:"baz,b=99" optdesc:"Baz description." optarg:"<num>"`
+		Qux    []string `optcfg:"qux,q=[A,B,C]" optdesc:"Qux description." optarg:"<text>"`
 	}
 	options := MyOptions{}
 
 	osArgs := []string{
+		"path/to/app",
 		"--foo-bar", "c1", "-b", "12", "--qux", "D", "c2", "-q", "E",
 	}
 
-	cmdParams, optCfgs, err := cliargs.ParseFor(osArgs, &options)
+	cmd, optCfgs, err := cliargs.ParseFor(osArgs, &options)
 	fmt.Printf("err = %v\n", err)
-	fmt.Printf("cmdParams = %v\n", cmdParams)
+	fmt.Printf("cmd.Name = %v\n", cmd.Name)
+	fmt.Printf("cmd.Args() = %v\n", cmd.Args())
 
 	fmt.Printf("optCfgs[0].Name = %v\n", optCfgs[0].Name)
 	fmt.Printf("optCfgs[0].Aliases = %v\n", optCfgs[0].Aliases)
-	fmt.Printf("optCfgs[0].HasParam = %v\n", optCfgs[0].HasParam)
+	fmt.Printf("optCfgs[0].HasArg = %v\n", optCfgs[0].HasArg)
 	fmt.Printf("optCfgs[0].IsArray = %v\n", optCfgs[0].IsArray)
 	fmt.Printf("optCfgs[0].Default = %v\n", optCfgs[0].Default)
 	fmt.Printf("optCfgs[0].Desc = %v\n", optCfgs[0].Desc)
 
 	fmt.Printf("optCfgs[1].Name = %v\n", optCfgs[1].Name)
 	fmt.Printf("optCfgs[1].Aliases = %v\n", optCfgs[1].Aliases)
-	fmt.Printf("optCfgs[1].HasParam = %v\n", optCfgs[1].HasParam)
+	fmt.Printf("optCfgs[1].HasArg = %v\n", optCfgs[1].HasArg)
 	fmt.Printf("optCfgs[1].IsArray = %v\n", optCfgs[1].IsArray)
 	fmt.Printf("optCfgs[1].Default = %v\n", optCfgs[1].Default)
 	fmt.Printf("optCfgs[1].Desc = %v\n", optCfgs[1].Desc)
-	fmt.Printf("optCfgs[1].AtParam = %v\n", optCfgs[1].AtParam)
+	fmt.Printf("optCfgs[1].HelpArg = %v\n", optCfgs[1].HelpArg)
 
 	fmt.Printf("optCfgs[2].Name = %v\n", optCfgs[2].Name)
 	fmt.Printf("optCfgs[2].Aliases = %v\n", optCfgs[2].Aliases)
-	fmt.Printf("optCfgs[2].HasParam = %v\n", optCfgs[2].HasParam)
+	fmt.Printf("optCfgs[2].HasArg = %v\n", optCfgs[2].HasArg)
 	fmt.Printf("optCfgs[2].IsArray = %v\n", optCfgs[2].IsArray)
 	fmt.Printf("optCfgs[2].Default = %v\n", optCfgs[2].Default)
 	fmt.Printf("optCfgs[2].Desc = %v\n", optCfgs[2].Desc)
-	fmt.Printf("optCfgs[2].AtParam = %v\n", optCfgs[2].AtParam)
+	fmt.Printf("optCfgs[2].HelpArg = %v\n", optCfgs[2].HelpArg)
 
 	fmt.Printf("options.FooBar = %v\n", options.FooBar)
 	fmt.Printf("options.Baz = %v\n", options.Baz)
@@ -50,27 +52,28 @@ func ExampleParseFor() {
 
 	// Output:
 	// err = <nil>
-	// cmdParams = [c1 c2]
+	// cmd.Name = app
+	// cmd.Args() = [c1 c2]
 	// optCfgs[0].Name = foo-bar
 	// optCfgs[0].Aliases = [f]
-	// optCfgs[0].HasParam = false
+	// optCfgs[0].HasArg = false
 	// optCfgs[0].IsArray = false
 	// optCfgs[0].Default = []
 	// optCfgs[0].Desc = FooBar description.
 	// optCfgs[1].Name = baz
 	// optCfgs[1].Aliases = [b]
-	// optCfgs[1].HasParam = true
+	// optCfgs[1].HasArg = true
 	// optCfgs[1].IsArray = false
 	// optCfgs[1].Default = [99]
 	// optCfgs[1].Desc = Baz description.
-	// optCfgs[1].AtParam = <num>
+	// optCfgs[1].HelpArg = <num>
 	// optCfgs[2].Name = qux
 	// optCfgs[2].Aliases = [q]
-	// optCfgs[2].HasParam = true
+	// optCfgs[2].HasArg = true
 	// optCfgs[2].IsArray = true
 	// optCfgs[2].Default = [A B C]
 	// optCfgs[2].Desc = Qux description.
-	// optCfgs[2].AtParam = <text>
+	// optCfgs[2].HelpArg = <text>
 	// options.FooBar = true
 	// options.Baz = 12
 	// options.Qux = [D E]
@@ -78,10 +81,10 @@ func ExampleParseFor() {
 
 func ExampleMakeOptCfgsFor() {
 	type MyOptions struct {
-		FooBar bool     `opt:"foo-bar,f" optdesc:"FooBar description"`
-		Baz    int      `opt:"baz,b=99" optdesc:"Baz description" optparam:"<number>"`
-		Qux    string   `opt:"=XXX" optdesc:"Qux description" optparam:"<string>"`
-		Quux   []string `opt:"quux=[A,B,C]" optdesc:"Quux description" optparam:"<array elem>"`
+		FooBar bool     `optcfg:"foo-bar,f" optdesc:"FooBar description"`
+		Baz    int      `optcfg:"baz,b=99" optdesc:"Baz description" optarg:"<number>"`
+		Qux    string   `optcfg:"=XXX" optdesc:"Qux description" optarg:"<string>"`
+		Quux   []string `optcfg:"quux=[A,B,C]" optdesc:"Quux description" optarg:"<array elem>"`
 		Corge  []int
 	}
 	options := MyOptions{}
@@ -92,38 +95,38 @@ func ExampleMakeOptCfgsFor() {
 	fmt.Println()
 	fmt.Printf("optCfgs[0].Name = %v\n", optCfgs[0].Name)
 	fmt.Printf("optCfgs[0].Aliases = %v\n", optCfgs[0].Aliases)
-	fmt.Printf("optCfgs[0].HasParam = %v\n", optCfgs[0].HasParam)
+	fmt.Printf("optCfgs[0].HasArg = %v\n", optCfgs[0].HasArg)
 	fmt.Printf("optCfgs[0].IsArray = %v\n", optCfgs[0].IsArray)
 	fmt.Printf("optCfgs[0].Default = %v\n", optCfgs[0].Default)
 	fmt.Printf("optCfgs[0].Desc = %v\n", optCfgs[0].Desc)
 	fmt.Println()
 	fmt.Printf("optCfgs[1].Name = %v\n", optCfgs[1].Name)
 	fmt.Printf("optCfgs[1].Aliases = %v\n", optCfgs[1].Aliases)
-	fmt.Printf("optCfgs[1].HasParam = %v\n", optCfgs[1].HasParam)
+	fmt.Printf("optCfgs[1].HasArg = %v\n", optCfgs[1].HasArg)
 	fmt.Printf("optCfgs[1].IsArray = %v\n", optCfgs[1].IsArray)
 	fmt.Printf("optCfgs[1].Default = %v\n", optCfgs[1].Default)
 	fmt.Printf("optCfgs[1].Desc = %v\n", optCfgs[1].Desc)
-	fmt.Printf("optCfgs[1].AtParam = %v\n", optCfgs[1].AtParam)
+	fmt.Printf("optCfgs[1].HelpArg = %v\n", optCfgs[1].HelpArg)
 	fmt.Println()
 	fmt.Printf("optCfgs[2].Name = %v\n", optCfgs[2].Name)
 	fmt.Printf("optCfgs[2].Aliases = %v\n", optCfgs[2].Aliases)
-	fmt.Printf("optCfgs[2].HasParam = %v\n", optCfgs[2].HasParam)
+	fmt.Printf("optCfgs[2].HasArg = %v\n", optCfgs[2].HasArg)
 	fmt.Printf("optCfgs[2].IsArray = %v\n", optCfgs[2].IsArray)
 	fmt.Printf("optCfgs[2].Default = %v\n", optCfgs[2].Default)
 	fmt.Printf("optCfgs[2].Desc = %v\n", optCfgs[2].Desc)
-	fmt.Printf("optCfgs[2].AtParam = %v\n", optCfgs[2].AtParam)
+	fmt.Printf("optCfgs[2].HelpArg = %v\n", optCfgs[2].HelpArg)
 	fmt.Println()
 	fmt.Printf("optCfgs[3].Name = %v\n", optCfgs[3].Name)
 	fmt.Printf("optCfgs[3].Aliases = %v\n", optCfgs[3].Aliases)
-	fmt.Printf("optCfgs[3].HasParam = %v\n", optCfgs[3].HasParam)
+	fmt.Printf("optCfgs[3].HasArg = %v\n", optCfgs[3].HasArg)
 	fmt.Printf("optCfgs[3].IsArray = %v\n", optCfgs[3].IsArray)
 	fmt.Printf("optCfgs[3].Default = %v\n", optCfgs[3].Default)
 	fmt.Printf("optCfgs[3].Desc = %v\n", optCfgs[3].Desc)
-	fmt.Printf("optCfgs[3].AtParam = %v\n", optCfgs[3].AtParam)
+	fmt.Printf("optCfgs[3].HelpArg = %v\n", optCfgs[3].HelpArg)
 	fmt.Println()
 	fmt.Printf("optCfgs[4].Name = %v\n", optCfgs[4].Name)
 	fmt.Printf("optCfgs[4].Aliases = %v\n", optCfgs[4].Aliases)
-	fmt.Printf("optCfgs[4].HasParam = %v\n", optCfgs[4].HasParam)
+	fmt.Printf("optCfgs[4].HasArg = %v\n", optCfgs[4].HasArg)
 	fmt.Printf("optCfgs[4].IsArray = %v\n", optCfgs[4].IsArray)
 	fmt.Printf("optCfgs[4].Default = %v\n", optCfgs[4].Default)
 	fmt.Printf("optCfgs[4].Desc = %v\n", optCfgs[4].Desc)
@@ -134,38 +137,38 @@ func ExampleMakeOptCfgsFor() {
 	//
 	// optCfgs[0].Name = foo-bar
 	// optCfgs[0].Aliases = [f]
-	// optCfgs[0].HasParam = false
+	// optCfgs[0].HasArg = false
 	// optCfgs[0].IsArray = false
 	// optCfgs[0].Default = []
 	// optCfgs[0].Desc = FooBar description
 	//
 	// optCfgs[1].Name = baz
 	// optCfgs[1].Aliases = [b]
-	// optCfgs[1].HasParam = true
+	// optCfgs[1].HasArg = true
 	// optCfgs[1].IsArray = false
 	// optCfgs[1].Default = [99]
 	// optCfgs[1].Desc = Baz description
-	// optCfgs[1].AtParam = <number>
+	// optCfgs[1].HelpArg = <number>
 	//
 	// optCfgs[2].Name = Qux
 	// optCfgs[2].Aliases = []
-	// optCfgs[2].HasParam = true
+	// optCfgs[2].HasArg = true
 	// optCfgs[2].IsArray = false
 	// optCfgs[2].Default = [XXX]
 	// optCfgs[2].Desc = Qux description
-	// optCfgs[2].AtParam = <string>
+	// optCfgs[2].HelpArg = <string>
 	//
 	// optCfgs[3].Name = quux
 	// optCfgs[3].Aliases = []
-	// optCfgs[3].HasParam = true
+	// optCfgs[3].HasArg = true
 	// optCfgs[3].IsArray = true
 	// optCfgs[3].Default = [A B C]
 	// optCfgs[3].Desc = Quux description
-	// optCfgs[3].AtParam = <array elem>
+	// optCfgs[3].HelpArg = <array elem>
 	//
 	// optCfgs[4].Name = Corge
 	// optCfgs[4].Aliases = []
-	// optCfgs[4].HasParam = true
+	// optCfgs[4].HasArg = true
 	// optCfgs[4].IsArray = true
 	// optCfgs[4].Default = []
 	// optCfgs[4].Desc =

--- a/example_parse-with_test.go
+++ b/example_parse-with_test.go
@@ -6,48 +6,52 @@ import (
 )
 
 func ExampleParseWith() {
-	osArgs := []string{"--foo-bar", "qux", "--baz", "1", "-z=2", "-X", "quux"}
+	osArgs := []string{
+		"path/to/app", "--foo-bar", "qux", "--baz", "1", "-z=2", "-X", "quux",
+	}
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{
 			Name: "foo-bar",
 		},
 		cliargs.OptCfg{
-			Name:     "baz",
-			Aliases:  []string{"z"},
-			HasParam: true,
-			IsArray:  true,
+			Name:    "baz",
+			Aliases: []string{"z"},
+			HasArg:  true,
+			IsArray: true,
 		},
 		cliargs.OptCfg{
-			Name:     "corge",
-			HasParam: true,
-			Default:  []string{"99"},
+			Name:    "corge",
+			HasArg:  true,
+			Default: []string{"99"},
 		},
 		cliargs.OptCfg{
 			Name: "*",
 		},
 	}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	fmt.Printf("err = %v\n", err)
-	fmt.Printf("args.HasOpt(\"foo-bar\") = %v\n", args.HasOpt("foo-bar"))
-	fmt.Printf("args.HasOpt(\"baz\") = %v\n", args.HasOpt("baz"))
-	fmt.Printf("args.HasOpt(\"X\") = %v\n", args.HasOpt("X"))
-	fmt.Printf("args.HasOpt(\"corge\") = %v\n", args.HasOpt("corge"))
-	fmt.Printf("args.OptParam(\"baz\") = %v\n", args.OptParam("baz"))
-	fmt.Printf("args.OptParam(\"corge\") = %v\n", args.OptParam("corge"))
-	fmt.Printf("args.OptParams(\"baz\") = %v\n", args.OptParams("baz"))
-	fmt.Printf("args.OptParams(\"corge\") = %v\n", args.OptParams("corge"))
-	fmt.Printf("args.CmdParams() = %v\n", args.CmdParams())
+	fmt.Printf("cmd.Name = %v\n", cmd.Name)
+	fmt.Printf("cmd.HasOpt(\"foo-bar\") = %v\n", cmd.HasOpt("foo-bar"))
+	fmt.Printf("cmd.HasOpt(\"baz\") = %v\n", cmd.HasOpt("baz"))
+	fmt.Printf("cmd.HasOpt(\"X\") = %v\n", cmd.HasOpt("X"))
+	fmt.Printf("cmd.HasOpt(\"corge\") = %v\n", cmd.HasOpt("corge"))
+	fmt.Printf("cmd.OptArg(\"baz\") = %v\n", cmd.OptArg("baz"))
+	fmt.Printf("cmd.OptArg(\"corge\") = %v\n", cmd.OptArg("corge"))
+	fmt.Printf("cmd.OptArgs(\"baz\") = %v\n", cmd.OptArgs("baz"))
+	fmt.Printf("cmd.OptArgs(\"corge\") = %v\n", cmd.OptArgs("corge"))
+	fmt.Printf("cmd.Args() = %v\n", cmd.Args())
 
 	// Output:
 	// err = <nil>
-	// args.HasOpt("foo-bar") = true
-	// args.HasOpt("baz") = true
-	// args.HasOpt("X") = true
-	// args.HasOpt("corge") = true
-	// args.OptParam("baz") = 1
-	// args.OptParam("corge") = 99
-	// args.OptParams("baz") = [1 2]
-	// args.OptParams("corge") = [99]
-	// args.CmdParams() = [qux quux]
+	// cmd.Name = app
+	// cmd.HasOpt("foo-bar") = true
+	// cmd.HasOpt("baz") = true
+	// cmd.HasOpt("X") = true
+	// cmd.HasOpt("corge") = true
+	// cmd.OptArg("baz") = 1
+	// cmd.OptArg("corge") = 99
+	// cmd.OptArgs("baz") = [1 2]
+	// cmd.OptArgs("corge") = [99]
+	// cmd.Args() = [qux quux]
 }

--- a/example_parse_test.go
+++ b/example_parse_test.go
@@ -11,31 +11,31 @@ func ExampleParse() {
 		"cmd", "--foo-bar=A", "-a", "--baz", "-bc=3", "qux", "-c=4", "quux",
 	}
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 	fmt.Printf("err = %v\n", err)
-	fmt.Printf("args.HasOpt(\"a\") = %v\n", args.HasOpt("a"))
-	fmt.Printf("args.HasOpt(\"b\") = %v\n", args.HasOpt("b"))
-	fmt.Printf("args.HasOpt(\"c\") = %v\n", args.HasOpt("c"))
-	fmt.Printf("args.HasOpt(\"foo-bar\") = %v\n", args.HasOpt("foo-bar"))
-	fmt.Printf("args.HasOpt(\"baz\") = %v\n", args.HasOpt("baz"))
-	fmt.Printf("args.OptParam(\"c\") = %v\n", args.OptParam("c"))
-	fmt.Printf("args.OptParam(\"foo-bar\") = %v\n", args.OptParam("foo-bar"))
-	fmt.Printf("args.OptParams(\"c\") = %v\n", args.OptParams("c"))
-	fmt.Printf("args.OptParams(\"foo-bar\") = %v\n", args.OptParams("foo-bar"))
-	fmt.Printf("args.CmdParams() = %v\n", args.CmdParams())
+	fmt.Printf("cmd.HasOpt(\"a\") = %v\n", cmd.HasOpt("a"))
+	fmt.Printf("cmd.HasOpt(\"b\") = %v\n", cmd.HasOpt("b"))
+	fmt.Printf("cmd.HasOpt(\"c\") = %v\n", cmd.HasOpt("c"))
+	fmt.Printf("cmd.HasOpt(\"foo-bar\") = %v\n", cmd.HasOpt("foo-bar"))
+	fmt.Printf("cmd.HasOpt(\"baz\") = %v\n", cmd.HasOpt("baz"))
+	fmt.Printf("cmd.OptArg(\"c\") = %v\n", cmd.OptArg("c"))
+	fmt.Printf("cmd.OptArg(\"foo-bar\") = %v\n", cmd.OptArg("foo-bar"))
+	fmt.Printf("cmd.OptArgs(\"c\") = %v\n", cmd.OptArgs("c"))
+	fmt.Printf("cmd.OptArgs(\"foo-bar\") = %v\n", cmd.OptArgs("foo-bar"))
+	fmt.Printf("cmd.Args() = %v\n", cmd.Args())
 
 	// Output:
 	// err = <nil>
-	// args.HasOpt("a") = true
-	// args.HasOpt("b") = true
-	// args.HasOpt("c") = true
-	// args.HasOpt("foo-bar") = true
-	// args.HasOpt("baz") = true
-	// args.OptParam("c") = 3
-	// args.OptParam("foo-bar") = A
-	// args.OptParams("c") = [3 4]
-	// args.OptParams("foo-bar") = [A]
-	// args.CmdParams() = [qux quux]
+	// cmd.HasOpt("a") = true
+	// cmd.HasOpt("b") = true
+	// cmd.HasOpt("c") = true
+	// cmd.HasOpt("foo-bar") = true
+	// cmd.HasOpt("baz") = true
+	// cmd.OptArg("c") = 3
+	// cmd.OptArg("foo-bar") = A
+	// cmd.OptArgs("c") = [3 4]
+	// cmd.OptArgs("foo-bar") = [A]
+	// cmd.Args() = [qux quux]
 
 	resetOsArgs()
 }

--- a/example_print-help_test.go
+++ b/example_print-help_test.go
@@ -7,10 +7,10 @@ import (
 
 func ExamplePrintHelp() {
 	type MyOptions struct {
-		FooBar bool     `opt:"foo-bar,f" optdesc:"FooBar is a flag.\nThis flag is foo bar."`
-		Baz    int      `opt:"baz,b=99" optdesc:"Baz is a integer."`
-		Qux    string   `opt:"=XXX" optdesc:"Qux is a string."`
-		Quux   []string `opt:"quux=[A,B,C]" optdesc:"Quux is a string array."`
+		FooBar bool     `optcfg:"foo-bar,f" optdesc:"FooBar is a flag.\nThis flag is foo bar."`
+		Baz    int      `optcfg:"baz,b=99" optdesc:"Baz is a integer."`
+		Qux    string   `optcfg:"=XXX" optdesc:"Qux is a string."`
+		Quux   []string `optcfg:"quux=[A,B,C]" optdesc:"Quux is a string array."`
 	}
 	options := MyOptions{}
 	optCfgs, _ := cliargs.MakeOptCfgsFor(&options)
@@ -35,10 +35,10 @@ func ExamplePrintHelp() {
 
 func ExampleMakeHelp() {
 	type MyOptions struct {
-		FooBar bool     `opt:"foo-bar,f" optdesc:"FooBar is a flag.\nThis flag is foo bar."`
-		Baz    int      `opt:"baz,b=99" optdesc:"Baz is a integer."`
-		Qux    string   `opt:"=XXX" optdesc:"Qux is a string."`
-		Quux   []string `opt:"quux=[A,B,C]" optdesc:"Quux is a string array."`
+		FooBar bool     `optcfg:"foo-bar,f" optdesc:"FooBar is a flag.\nThis flag is foo bar."`
+		Baz    int      `optcfg:"baz,b=99" optdesc:"Baz is a integer."`
+		Qux    string   `optcfg:"=XXX" optdesc:"Qux is a string."`
+		Quux   []string `optcfg:"quux=[A,B,C]" optdesc:"Quux is a string array."`
 	}
 	options := MyOptions{}
 	optCfgs, _ := cliargs.MakeOptCfgsFor(&options)

--- a/parse-with.go
+++ b/parse-with.go
@@ -6,24 +6,25 @@ package cliargs
 
 import (
 	"fmt"
+	"path"
 )
 
-// ConfigIsArrayButHasNoParam is an error which indicates that an option
+// ConfigIsArrayButHasNoArg is an error which indicates that an option
 // configuration contradicts that the option must be an array
-// (.IsArray = true) but must have no option parameter (.HasParam = false).
-type ConfigIsArrayButHasNoParam struct{ Option string }
+// (.IsArray = true) but must have no option argument (.HasArg = false).
+type ConfigIsArrayButHasNoArg struct{ Option string }
 
-func (e ConfigIsArrayButHasNoParam) Error() string {
-	return fmt.Sprintf("ConfigIsArrayButHasNoParam{Option:%s}", e.Option)
+func (e ConfigIsArrayButHasNoArg) Error() string {
+	return fmt.Sprintf("ConfigIsArrayButHasNoArg{Option:%s}", e.Option)
 }
 
-// ConfigHasDefaultButHasNoParam is an error which indicates that an option
+// ConfigHasDefaultButHasNoArg is an error which indicates that an option
 // configuration contradicts that the option has default value
-// (.Default != nil) but must have no option parameter (.HasParam = false).
-type ConfigHasDefaultButHasNoParam struct{ Option string }
+// (.Default != nil) but must have no option argument (.HasArg = false).
+type ConfigHasDefaultButHasNoArg struct{ Option string }
 
-func (e ConfigHasDefaultButHasNoParam) Error() string {
-	return fmt.Sprintf("ConfigHasDefaultButHasNoParam{Option:%s}", e.Option)
+func (e ConfigHasDefaultButHasNoArg) Error() string {
+	return fmt.Sprintf("ConfigHasDefaultButHasNoArg{Option:%s}", e.Option)
 }
 
 // UnconfiguredOption is an error which indicates that there is no
@@ -34,26 +35,26 @@ func (e UnconfiguredOption) Error() string {
 	return fmt.Sprintf("UnconfiguredOption{Option:%s}", e.Option)
 }
 
-// OptionNeedsParam is an error which indicates that an option is input with
-// no option parameter though its option configuration requires option
-// parameters (.HasParam = true).
-type OptionNeedsParam struct{ Option string }
+// OptionNeedsArg is an error which indicates that an option is input with
+// no option argument though its option configuration requires option
+// argument (.HasArg = true).
+type OptionNeedsArg struct{ Option string }
 
-func (e OptionNeedsParam) Error() string {
-	return fmt.Sprintf("OptionNeedsParam{Option:%s}", e.Option)
+func (e OptionNeedsArg) Error() string {
+	return fmt.Sprintf("OptionNeedsArg{Option:%s}", e.Option)
 }
 
-// OptionTakesNoParam is an error which indicates that an option isinput with
-// an option parameter though its option configuration does not accept option
-// parameters (.HasParam = false).
-type OptionTakesNoParam struct{ Option string }
+// OptionTakesNoArg is an error which indicates that an option isinput with
+// an option argument though its option configuration does not accept option
+// arguments (.HasArg = false).
+type OptionTakesNoArg struct{ Option string }
 
-func (e OptionTakesNoParam) Error() string {
-	return fmt.Sprintf("OptionTakesNoParam{Option:%s}", e.Option)
+func (e OptionTakesNoArg) Error() string {
+	return fmt.Sprintf("OptionTakesNoArg{Option:%s}", e.Option)
 }
 
 // OptionIsNotArray is an error which indicates that an option is input with
-// an option parameter multiple times though its option configuration specifies
+// an option argument multiple times though its option configuration specifies
 // the option is not an array (.IsArray = false).
 type OptionIsNotArray struct{ Option string }
 
@@ -64,57 +65,57 @@ func (e OptionIsNotArray) Error() string {
 const anyOption = "*"
 
 // OptCfg is a structure that represents an option configuration.
-// An option configuration consists of fields: Name, Aliases, HasParam,
-// IsArray, Default, OnParsed, Desc, and AtParam.
-
+// An option configuration consists of fields: Name, Aliases, HasArg,
+// IsArray, Default, OnParsed, Desc, and HelpArg.
+//
 // Name is the option name and Aliases are the another names.
 // Options given by those names in command line arguments are all registered to
 // Args with the Name.
 //
-// HasParam and IsArray are flags which allows the option to take option
-// parameters.
-// If both HasParam and IsArray are true, the option can take one or multiple
-// option parameters.
-// If HasParam is true and IsArray is false, the option can take only one
-// option parameter.
-// If both HasParam and IsArray are false, the option can take no option
-// parameter.
+// HasArg and IsArray are flags which allows the option to take option
+// arguments.
+// If both HasArg and IsArray are true, the option can take one or multiple
+// option arguments.
+// If HasArg is true and IsArray is false, the option can take only one
+// option arguments.
+// If both HasArg and IsArray are false, the option can take no option
+// argument.
 //
 // Default is the field to specify the default value for when the option is not
 // given in command line arguments.
 //
 // OnParsed is the field for the event handler which is called when the option
 // has been parsed.
-// This handler receives a string array which is the option parameter(s) as its
+// This handler receives a string array which is the option argument(s) as its
 // argument.
 // If this field is nil, nothing is done after parsing.
 //
 // Desc is the field to set the description of the option.
 //
-// AtParam is a display at a parameter position of this option in a help text.
+// HelpArg is a display at a argument position of this option in a help text.
 // This string is for a display like: -o, --option <value>.
 type OptCfg struct {
 	Name     string
 	Aliases  []string
-	HasParam bool
+	HasArg   bool
 	IsArray  bool
 	Default  []string
 	OnParsed *func([]string) error
 	Desc     string
-	AtParam  string
+	HelpArg  string
 }
 
 // ParseWith is a function which parses command line arguments with option
 // configurations.
-// This function divides command line arguments to command parameters and
-// options, and an option consists of a name and option parameters.
+// This function divides command line arguments to command arguments and
+// options, and an option consists of a name and option arguments.
 // Options are divided to long format options and short format options.
 // About long/short format options, since they are same with Parse function,
 // see the comment of the function.
 //
 // This function allows only options declared in option configurations.
-// A option configuration has fields: Name, Aliases, HasParam, IsArray, and
-// Default.
+// A option configuration has fields: Name, Aliases, HasArg, IsArray, and
+// Default, HelpArg.
 // When an option matches Name or includes in Aliases in an option
 // configuration, the option is registered in Args with the Name.
 // If both HasParam and IsArray are true, the option can has one or multiple
@@ -128,18 +129,18 @@ type OptCfg struct {
 // arguments, this function basically returns UnconfiguredOption error.
 // If you want to allow other options, add an option configuration of which
 // Name is "*" (but HasParam and IsArray of this configuration is ignored).
-func ParseWith(args []string, optCfgs []OptCfg) (Args, error) {
+func ParseWith(osArgs []string, optCfgs []OptCfg) (Cmd, error) {
 	hasAnyOpt := false
 	cfgMap := make(map[string]int)
 	for i, cfg := range optCfgs {
-		if !cfg.HasParam {
+		if !cfg.HasArg {
 			if cfg.IsArray {
-				err := ConfigIsArrayButHasNoParam{Option: cfg.Name}
-				return Args{cmdParams: empty}, err
+				err := ConfigIsArrayButHasNoArg{Option: cfg.Name}
+				return Cmd{args: empty}, err
 			}
 			if cfg.Default != nil {
-				err := ConfigHasDefaultButHasNoParam{Option: cfg.Name}
-				return Args{cmdParams: empty}, err
+				err := ConfigHasDefaultButHasNoArg{Option: cfg.Name}
+				return Cmd{args: empty}, err
 			}
 		}
 		if cfg.Name == anyOption {
@@ -152,52 +153,52 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, error) {
 		}
 	}
 
-	var takeParam = func(opt string) bool {
+	var takeArg = func(opt string) bool {
 		i, exists := cfgMap[opt]
 		if exists {
-			return optCfgs[i].HasParam
+			return optCfgs[i].HasArg
 		}
 		return false
 	}
 
-	var cmdParams = make([]string, 0)
-	var optParams = make(map[string][]string)
+	var args = make([]string, 0)
+	var opts = make(map[string][]string)
 
-	var collCmdParams = func(params ...string) error {
-		cmdParams = append(cmdParams, params...)
+	var collectArg = func(a ...string) error {
+		args = append(args, a...)
 		return nil
 	}
-	var collOptParams = func(opt string, params ...string) error {
-		i, exists := cfgMap[opt]
+	var collectOpt = func(name string, a ...string) error {
+		i, exists := cfgMap[name]
 		if !exists {
 			if !hasAnyOpt {
-				return UnconfiguredOption{Option: opt}
+				return UnconfiguredOption{Option: name}
 			}
 
-			arr := optParams[opt]
+			arr := opts[name]
 			if arr == nil {
 				arr = empty
 			}
-			optParams[opt] = append(arr, params...)
+			opts[name] = append(arr, a...)
 			return nil
 		}
 
 		cfg := optCfgs[i]
-		if !cfg.HasParam {
-			if len(params) > 0 {
-				return OptionTakesNoParam{Option: cfg.Name}
+		if !cfg.HasArg {
+			if len(a) > 0 {
+				return OptionTakesNoArg{Option: cfg.Name}
 			}
 		} else {
-			if len(params) == 0 {
-				return OptionNeedsParam{Option: cfg.Name}
+			if len(a) == 0 {
+				return OptionNeedsArg{Option: cfg.Name}
 			}
 		}
 
-		arr := optParams[cfg.Name]
+		arr := opts[cfg.Name]
 		if arr == nil {
 			arr = empty
 		}
-		arr = append(arr, params...)
+		arr = append(arr, a...)
 
 		if !cfg.IsArray {
 			if len(arr) > 1 {
@@ -205,28 +206,38 @@ func ParseWith(args []string, optCfgs []OptCfg) (Args, error) {
 			}
 		}
 
-		optParams[cfg.Name] = arr
+		opts[cfg.Name] = arr
 		return nil
 	}
 
-	err := parseArgs(args, collCmdParams, collOptParams, takeParam)
+	var cmdName string
+	if len(osArgs) > 0 {
+		cmdName = path.Base(osArgs[0])
+	}
+
+	var osArgs1 []string
+	if len(osArgs) > 1 {
+		osArgs1 = osArgs[1:]
+	}
+
+	err := parseArgs(osArgs1, collectArg, collectOpt, takeArg)
 	if err != nil {
-		return Args{cmdParams: empty}, err
+		return Cmd{args: empty}, err
 	}
 
 	for _, cfg := range optCfgs {
-		arr, exists := optParams[cfg.Name]
+		arr, exists := opts[cfg.Name]
 		if !exists && cfg.Default != nil {
 			arr = cfg.Default
-			optParams[cfg.Name] = arr
+			opts[cfg.Name] = arr
 		}
 		if cfg.OnParsed != nil {
 			err = (*cfg.OnParsed)(arr)
 			if err != nil {
-				return Args{cmdParams: empty}, err
+				return Cmd{args: empty}, err
 			}
 		}
 	}
 
-	return Args{cmdParams: cmdParams, optParams: optParams}, err
+	return Cmd{Name: cmdName, args: args, opts: opts}, nil
 }

--- a/parse-with_test.go
+++ b/parse-with_test.go
@@ -11,33 +11,35 @@ func TestParseWith_zeroCfgAndZeroArg(t *testing.T) {
 
 	osArgs := []string{}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
-func TestParseWith_zeroCfgAndOneCommandParam(t *testing.T) {
+func TestParseWith_zeroCfgAndOneCommandArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{}
 
-	osArgs := []string{"foo-bar"}
+	osArgs := []string{"/path/to/app", "foo-bar"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{"foo-bar"})
+	assert.Equal(t, cmd.Name, "app")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{"foo-bar"})
 }
 
 func testParseWith_zeroCfgAndOneLongOpt(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{}
 
-	osArgs := []string{"--foo-bar"}
+	osArgs := []string{"path/to/app", "--foo-bar"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "UnconfiguredOption")
 	switch err.(type) {
@@ -46,21 +48,22 @@ func testParseWith_zeroCfgAndOneLongOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_zeroCfgAndOneShortOpt(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{}
 
-	osArgs := []string{"-f"}
+	osArgs := []string{"path/to/app", "-f"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:f}")
 	switch err.(type) {
@@ -69,13 +72,14 @@ func TestParseWith_zeroCfgAndOneShortOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_oneCfgAndZeroOpt(t *testing.T) {
@@ -85,33 +89,35 @@ func TestParseWith_oneCfgAndZeroOpt(t *testing.T) {
 
 	osArgs := []string{}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
-func TestParseWith_oneCfgAndOneCmdParam(t *testing.T) {
+func TestParseWith_oneCfgAndOneCmdArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{Name: "foo-bar"},
 	}
 
-	osArgs := []string{"foo-bar"}
+	osArgs := []string{"path/to/app", "foo-bar"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{"foo-bar"})
+	assert.Equal(t, cmd.Name, "app")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{"foo-bar"})
 }
 
 func TestParseWith_oneCfgAndOneLongOpt(t *testing.T) {
@@ -119,17 +125,18 @@ func TestParseWith_oneCfgAndOneLongOpt(t *testing.T) {
 		cliargs.OptCfg{Name: "foo-bar"},
 	}
 
-	osArgs := []string{"--foo-bar"}
+	osArgs := []string{"path/to/app", "--foo-bar"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_oneCfgAndOneShortOpt(t *testing.T) {
@@ -137,17 +144,18 @@ func TestParseWith_oneCfgAndOneShortOpt(t *testing.T) {
 		cliargs.OptCfg{Name: "f"},
 	}
 
-	osArgs := []string{"-f"}
+	osArgs := []string{"app", "-f"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.True(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string{})
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.True(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string{})
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_oneCfgAndOneDifferentLongOpt(t *testing.T) {
@@ -155,9 +163,9 @@ func TestParseWith_oneCfgAndOneDifferentLongOpt(t *testing.T) {
 		cliargs.OptCfg{Name: "foo-bar"},
 	}
 
-	osArgs := []string{"--boo-far"}
+	osArgs := []string{"app", "--boo-far"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:boo-far}")
 	switch err.(type) {
@@ -166,13 +174,14 @@ func TestParseWith_oneCfgAndOneDifferentLongOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_oneCfgAndOneDifferentShortOpt(t *testing.T) {
@@ -180,9 +189,9 @@ func TestParseWith_oneCfgAndOneDifferentShortOpt(t *testing.T) {
 		cliargs.OptCfg{Name: "f"},
 	}
 
-	osArgs := []string{"-b"}
+	osArgs := []string{"app", "-b"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "UnconfiguredOption{Option:b}")
 	switch err.(type) {
@@ -191,13 +200,14 @@ func TestParseWith_oneCfgAndOneDifferentShortOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_anyOptCfgAndOneDifferentLongOpt(t *testing.T) {
@@ -206,21 +216,22 @@ func TestParseWith_anyOptCfgAndOneDifferentLongOpt(t *testing.T) {
 		cliargs.OptCfg{Name: "*"},
 	}
 
-	osArgs := []string{"--boo-far"}
+	osArgs := []string{"app", "--boo-far"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	assert.True(t, args.HasOpt("boo-far"))
-	assert.Equal(t, args.OptParam("boo-far"), "")
-	assert.Equal(t, args.OptParams("boo-far"), []string{})
+	assert.True(t, cmd.HasOpt("boo-far"))
+	assert.Equal(t, cmd.OptArg("boo-far"), "")
+	assert.Equal(t, cmd.OptArgs("boo-far"), []string{})
 }
 
 func TestParseWith_anyOptCfgAndOneDifferentShortOpt(t *testing.T) {
@@ -229,515 +240,523 @@ func TestParseWith_anyOptCfgAndOneDifferentShortOpt(t *testing.T) {
 		cliargs.OptCfg{Name: "*"},
 	}
 
-	osArgs := []string{"-b"}
+	osArgs := []string{"app", "-b"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	assert.True(t, args.HasOpt("b"))
-	assert.Equal(t, args.OptParam("b"), "")
-	assert.Equal(t, args.OptParams("b"), []string{})
+	assert.True(t, cmd.HasOpt("b"))
+	assert.Equal(t, cmd.OptArg("b"), "")
+	assert.Equal(t, cmd.OptArgs("b"), []string{})
 }
 
-func TestParseWith_oneCfgHasParamAndOneLongOptHasParam(t *testing.T) {
+func TestParseWith_oneCfgHasArgAndOneLongOptHasArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
-		cliargs.OptCfg{Name: "foo-bar", HasParam: true},
+		cliargs.OptCfg{Name: "foo-bar", HasArg: true},
 	}
 
-	osArgs := []string{"--foo-bar", "ABC"}
+	osArgs := []string{"app", "--foo-bar", "ABC"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"--foo-bar=ABC"}
+	osArgs = []string{"app", "--foo-bar=ABC"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"--foo-bar", ""}
+	osArgs = []string{"app", "--foo-bar", ""}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{""})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{""})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"--foo-bar="}
+	osArgs = []string{"app", "--foo-bar="}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{""})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{""})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
-func TestParseWith_oneCfgHasParamAndOneShortOptHasParam(t *testing.T) {
+func TestParseWith_oneCfgHasArgAndOneShortOptHasArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
-		cliargs.OptCfg{Name: "f", HasParam: true},
+		cliargs.OptCfg{Name: "f", HasArg: true},
 	}
 
-	osArgs := []string{"-f", "ABC"}
+	osArgs := []string{"app", "-f", "ABC"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.True(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "ABC")
-	assert.Equal(t, args.OptParams("f"), []string{"ABC"})
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.True(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "ABC")
+	assert.Equal(t, cmd.OptArgs("f"), []string{"ABC"})
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"-f=ABC"}
+	osArgs = []string{"app", "-f=ABC"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.True(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "ABC")
-	assert.Equal(t, args.OptParams("f"), []string{"ABC"})
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.True(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "ABC")
+	assert.Equal(t, cmd.OptArgs("f"), []string{"ABC"})
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"-f", ""}
+	osArgs = []string{"app", "-f", ""}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.True(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string{""})
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.True(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string{""})
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"-f="}
+	osArgs = []string{"app", "-f="}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.True(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string{""})
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.True(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string{""})
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
-func TestParseWith_oneCfgHasParamButOneLongOptHasNoParam(t *testing.T) {
+func TestParseWith_oneCfgHasArgButOneLongOptHasNoArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
-		cliargs.OptCfg{Name: "foo-bar", HasParam: true},
+		cliargs.OptCfg{Name: "foo-bar", HasArg: true},
 	}
 
-	osArgs := []string{"--foo-bar"}
+	osArgs := []string{"app", "--foo-bar"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionNeedsParam{Option:foo-bar}")
+	assert.Equal(t, err.Error(), "OptionNeedsArg{Option:foo-bar}")
 	switch err.(type) {
-	case cliargs.OptionNeedsParam:
-		assert.Equal(t, err.(cliargs.OptionNeedsParam).Option, "foo-bar")
+	case cliargs.OptionNeedsArg:
+		assert.Equal(t, err.(cliargs.OptionNeedsArg).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
-func TestParseWith_oneCfgHasParamAndOneShortOptHasNoParam(t *testing.T) {
+func TestParseWith_oneCfgHasArgAndOneShortOptHasNoArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
-		cliargs.OptCfg{Name: "f", HasParam: true},
+		cliargs.OptCfg{Name: "f", HasArg: true},
 	}
 
-	osArgs := []string{"-f"}
+	osArgs := []string{"app", "-f"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionNeedsParam{Option:f}")
+	assert.Equal(t, err.Error(), "OptionNeedsArg{Option:f}")
 	switch err.(type) {
-	case cliargs.OptionNeedsParam:
-		assert.Equal(t, err.(cliargs.OptionNeedsParam).Option, "f")
+	case cliargs.OptionNeedsArg:
+		assert.Equal(t, err.(cliargs.OptionNeedsArg).Option, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
-func TestParseWith_oneCfgHasNoParamAndOneLongOptHasParam(t *testing.T) {
+func TestParseWith_oneCfgHasNoArgAndOneLongOptHasArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{Name: "foo-bar"},
 	}
 
-	osArgs := []string{"--foo-bar", "ABC"}
+	osArgs := []string{"app", "--foo-bar", "ABC"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{"ABC"})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{"ABC"})
 
-	osArgs = []string{"--foo-bar=ABC"}
+	osArgs = []string{"app", "--foo-bar=ABC"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionTakesNoParam{Option:foo-bar}")
+	assert.Equal(t, err.Error(), "OptionTakesNoArg{Option:foo-bar}")
 	switch err.(type) {
-	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "foo-bar")
+	case cliargs.OptionTakesNoArg:
+		assert.Equal(t, err.(cliargs.OptionTakesNoArg).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"--foo-bar", ""}
+	osArgs = []string{"app", "--foo-bar", ""}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{""})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{""})
 
-	osArgs = []string{"--foo-bar="}
+	osArgs = []string{"app", "--foo-bar="}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionTakesNoParam{Option:foo-bar}")
+	assert.Equal(t, err.Error(), "OptionTakesNoArg{Option:foo-bar}")
 	switch err.(type) {
-	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "foo-bar")
+	case cliargs.OptionTakesNoArg:
+		assert.Equal(t, err.(cliargs.OptionTakesNoArg).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
-func TestParseWith_oneCfgHasNoParamAndOneShortOptHasParam(t *testing.T) {
+func TestParseWith_oneCfgHasNoArgAndOneShortOptHasArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{Name: "f"},
 	}
 
-	osArgs := []string{"-f", "ABC"}
+	osArgs := []string{"app", "-f", "ABC"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.True(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string{})
-	assert.Equal(t, args.CmdParams(), []string{"ABC"})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.True(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string{})
+	assert.Equal(t, cmd.Args(), []string{"ABC"})
 
-	osArgs = []string{"-f=ABC"}
+	osArgs = []string{"app", "-f=ABC"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionTakesNoParam{Option:f}")
+	assert.Equal(t, err.Error(), "OptionTakesNoArg{Option:f}")
 	switch err.(type) {
-	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "f")
+	case cliargs.OptionTakesNoArg:
+		assert.Equal(t, err.(cliargs.OptionTakesNoArg).Option, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
 
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"-f", ""}
+	osArgs = []string{"app", "-f", ""}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.True(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string{})
-	assert.Equal(t, args.CmdParams(), []string{""})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.True(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string{})
+	assert.Equal(t, cmd.Args(), []string{""})
 
-	osArgs = []string{"-f="}
+	osArgs = []string{"app", "-f="}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "OptionTakesNoParam{Option:f}")
+	assert.Equal(t, err.Error(), "OptionTakesNoArg{Option:f}")
 	switch err.(type) {
-	case cliargs.OptionTakesNoParam:
-		assert.Equal(t, err.(cliargs.OptionTakesNoParam).Option, "f")
+	case cliargs.OptionTakesNoArg:
+		assert.Equal(t, err.(cliargs.OptionTakesNoArg).Option, "f")
 	default:
 		assert.Fail(t, err.Error())
 	}
 
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
-func TestParseWith_oneCfgHasNoParamButIsArray(t *testing.T) {
+func TestParseWith_oneCfgHasNoArgButIsArray(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
-		cliargs.OptCfg{Name: "foo-bar", HasParam: false, IsArray: true},
+		cliargs.OptCfg{Name: "foo-bar", HasArg: false, IsArray: true},
 	}
 
-	osArgs := []string{"--foo-bar", "ABC"}
+	osArgs := []string{"app", "--foo-bar", "ABC"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "ConfigIsArrayButHasNoParam{Option:foo-bar}")
+	assert.Equal(t, err.Error(), "ConfigIsArrayButHasNoArg{Option:foo-bar}")
 	switch err.(type) {
-	case cliargs.ConfigIsArrayButHasNoParam:
-		assert.Equal(t, err.(cliargs.ConfigIsArrayButHasNoParam).Option, "foo-bar")
+	case cliargs.ConfigIsArrayButHasNoArg:
+		assert.Equal(t, err.(cliargs.ConfigIsArrayButHasNoArg).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
-func TestParseWith_oneCfgIsArrayAndOptHasOneParam(t *testing.T) {
+func TestParseWith_oneCfgIsArrayAndOptHasOneArg(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
-		cliargs.OptCfg{Name: "foo-bar", HasParam: true, IsArray: true},
-		cliargs.OptCfg{Name: "f", HasParam: true, IsArray: true},
+		cliargs.OptCfg{Name: "foo-bar", HasArg: true, IsArray: true},
+		cliargs.OptCfg{Name: "f", HasArg: true, IsArray: true},
 	}
 
-	osArgs := []string{"--foo-bar", "ABC"}
+	osArgs := []string{"app", "--foo-bar", "ABC"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"--foo-bar", "ABC", "--foo-bar=DEF"}
+	osArgs = []string{"app", "--foo-bar", "ABC", "--foo-bar=DEF"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC", "DEF"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC", "DEF"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"-f", "ABC"}
+	osArgs = []string{"app", "-f", "ABC"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.True(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "ABC")
-	assert.Equal(t, args.OptParams("f"), []string{"ABC"})
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.True(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "ABC")
+	assert.Equal(t, cmd.OptArgs("f"), []string{"ABC"})
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"-f", "ABC", "-f=DEF"}
+	osArgs = []string{"app", "-f", "ABC", "-f=DEF"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.True(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "ABC")
-	assert.Equal(t, args.OptParams("f"), []string{"ABC", "DEF"})
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.True(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "ABC")
+	assert.Equal(t, cmd.OptArgs("f"), []string{"ABC", "DEF"})
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_oneCfgHasAliasesAndArgMatchesName(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{
-			Name:     "foo-bar",
-			Aliases:  []string{"f", "b"},
-			HasParam: true,
+			Name:    "foo-bar",
+			Aliases: []string{"f", "b"},
+			HasArg:  true,
 		},
 	}
 
-	osArgs := []string{"--foo-bar", "ABC"}
+	osArgs := []string{"app", "--foo-bar", "ABC"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"--foo-bar=ABC"}
+	osArgs = []string{"app", "--foo-bar=ABC"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_oneCfgHasAliasesAndArgMatchesAliases(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{
-			Name:     "foo-bar",
-			Aliases:  []string{"f"},
-			HasParam: true,
+			Name:    "foo-bar",
+			Aliases: []string{"f"},
+			HasArg:  true,
 		},
 	}
 
-	osArgs := []string{"-f", "ABC"}
+	osArgs := []string{"app", "-f", "ABC"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"-f=ABC"}
+	osArgs = []string{"app", "-f=ABC"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_combineOptsByNameAndAliases(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{
-			Name:     "foo-bar",
-			Aliases:  []string{"f"},
-			HasParam: true,
-			IsArray:  true,
+			Name:    "foo-bar",
+			Aliases: []string{"f"},
+			HasArg:  true,
+			IsArray: true,
 		},
 	}
 
-	osArgs := []string{"-f", "ABC", "--foo-bar=DEF"}
+	osArgs := []string{"app", "-f", "ABC", "--foo-bar=DEF"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC", "DEF"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC", "DEF"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 
-	osArgs = []string{"-f=ABC", "--foo-bar", "DEF"}
+	osArgs = []string{"app", "-f=ABC", "--foo-bar", "DEF"}
 
-	args, err = cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err = cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "ABC")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{"ABC", "DEF"})
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "ABC")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{"ABC", "DEF"})
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{
-			Name:     "foo-bar",
-			Aliases:  []string{"f"},
-			HasParam: true,
-			IsArray:  false,
+			Name:    "foo-bar",
+			Aliases: []string{"f"},
+			HasArg:  true,
+			IsArray: false,
 		},
 	}
 
-	osArgs := []string{"-f", "ABC", "--foo-bar=DEF"}
+	osArgs := []string{"app", "-f", "ABC", "--foo-bar=DEF"}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionIsNotArray{Option:foo-bar}")
 	switch err.(type) {
@@ -746,83 +765,88 @@ func TestParseWith_oneCfgIsNotArrayButOptsAreMultiple(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_specifyDefault(t *testing.T) {
 	osArgs := []string{}
 	optCfgs := []cliargs.OptCfg{
-		cliargs.OptCfg{Name: "bar", HasParam: true, Default: []string{"A"}},
-		cliargs.OptCfg{Name: "baz", HasParam: true, IsArray: true, Default: []string{"A"}},
+		cliargs.OptCfg{Name: "bar", HasArg: true, Default: []string{"A"}},
+		cliargs.OptCfg{Name: "baz", HasArg: true, IsArray: true, Default: []string{"A"}},
 	}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.False(t, args.HasOpt("foo"))
-	assert.True(t, args.HasOpt("bar"))
-	assert.True(t, args.HasOpt("baz"))
-	assert.Equal(t, args.OptParam("foo"), "")
-	assert.Equal(t, args.OptParam("bar"), "A")
-	assert.Equal(t, args.OptParam("baz"), "A")
-	assert.Equal(t, args.OptParams("foo"), []string(nil))
-	assert.Equal(t, args.OptParams("bar"), []string{"A"})
-	assert.Equal(t, args.OptParams("baz"), []string{"A"})
+	assert.Equal(t, cmd.Name, "")
+	assert.False(t, cmd.HasOpt("foo"))
+	assert.True(t, cmd.HasOpt("bar"))
+	assert.True(t, cmd.HasOpt("baz"))
+	assert.Equal(t, cmd.OptArg("foo"), "")
+	assert.Equal(t, cmd.OptArg("bar"), "A")
+	assert.Equal(t, cmd.OptArg("baz"), "A")
+	assert.Equal(t, cmd.OptArgs("foo"), []string(nil))
+	assert.Equal(t, cmd.OptArgs("bar"), []string{"A"})
+	assert.Equal(t, cmd.OptArgs("baz"), []string{"A"})
 }
 
-func TestParseWith_oneCfgHasNoParamButHasDefault(t *testing.T) {
+func TestParseWith_oneCfgHasNoArgButHasDefault(t *testing.T) {
 	optCfgs := []cliargs.OptCfg{
-		cliargs.OptCfg{Name: "foo-bar", HasParam: false, Default: []string{"A"}},
+		cliargs.OptCfg{Name: "foo-bar", HasArg: false, Default: []string{"A"}},
 	}
 
 	osArgs := []string{}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "ConfigHasDefaultButHasNoParam{Option:foo-bar}")
+	assert.Equal(t, err.Error(), "ConfigHasDefaultButHasNoArg{Option:foo-bar}")
 	switch err.(type) {
-	case cliargs.ConfigHasDefaultButHasNoParam:
-		assert.Equal(t, err.(cliargs.ConfigHasDefaultButHasNoParam).Option, "foo-bar")
+	case cliargs.ConfigHasDefaultButHasNoArg:
+		assert.Equal(t, err.(cliargs.ConfigHasDefaultButHasNoArg).Option, "foo-bar")
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.False(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string(nil))
-	assert.False(t, args.HasOpt("f"))
-	assert.Equal(t, args.OptParam("f"), "")
-	assert.Equal(t, args.OptParams("f"), []string(nil))
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, cmd.Name, "")
+	assert.False(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string(nil))
+	assert.False(t, cmd.HasOpt("f"))
+	assert.Equal(t, cmd.OptArg("f"), "")
+	assert.Equal(t, cmd.OptArgs("f"), []string(nil))
+	assert.Equal(t, cmd.Args(), []string{})
 }
 
 func TestParseWith_multipleArgs(t *testing.T) {
-	osArgs := []string{"--foo-bar", "qux", "--baz", "1", "-z=2", "-X", "quux"}
+	osArgs := []string{"app", "--foo-bar", "qux", "--baz", "1", "-z=2", "-X", "quux"}
+
 	optCfgs := []cliargs.OptCfg{
 		cliargs.OptCfg{Name: "foo-bar"},
 		cliargs.OptCfg{
-			Name:     "baz",
-			Aliases:  []string{"z"},
-			HasParam: true,
-			IsArray:  true,
+			Name:    "baz",
+			Aliases: []string{"z"},
+			HasArg:  true,
+			IsArray: true,
 		},
-		cliargs.OptCfg{Name: "corge", HasParam: true, Default: []string{"99"}},
+		cliargs.OptCfg{Name: "corge", HasArg: true, Default: []string{"99"}},
 		cliargs.OptCfg{Name: "*"},
 	}
 
-	args, err := cliargs.ParseWith(osArgs, optCfgs)
+	cmd, err := cliargs.ParseWith(osArgs, optCfgs)
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.True(t, args.HasOpt("baz"))
-	assert.True(t, args.HasOpt("X"))
-	assert.True(t, args.HasOpt("corge"))
-	assert.Equal(t, args.OptParam("baz"), "1")
-	assert.Equal(t, args.OptParams("baz"), []string{"1", "2"})
-	assert.Equal(t, args.OptParam("corge"), "99")
-	assert.Equal(t, args.OptParams("corge"), []string{"99"})
-	assert.Equal(t, args.CmdParams(), []string{"qux", "quux"})
+	assert.Equal(t, cmd.Name, "app")
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.True(t, cmd.HasOpt("baz"))
+	assert.True(t, cmd.HasOpt("X"))
+	assert.True(t, cmd.HasOpt("corge"))
+	assert.Equal(t, cmd.OptArg("baz"), "1")
+	assert.Equal(t, cmd.OptArgs("baz"), []string{"1", "2"})
+	assert.Equal(t, cmd.OptArg("corge"), "99")
+	assert.Equal(t, cmd.OptArgs("corge"), []string{"99"})
+	assert.Equal(t, cmd.Args(), []string{"qux", "quux"})
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -17,288 +17,300 @@ func TestParse_zeroArg(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 1)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "/path/to/app"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_oneNonOptArg(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "path/to/app"
 	os.Args[1] = "abcd"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{"abcd"})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{"abcd"})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_oneLongOpt(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "app"
 	os.Args[1] = "--silent"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
-	assert.True(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string{})
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.True(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string{})
 }
 
-func TestParse_oneLongOptWithParam(t *testing.T) {
+func TestParse_oneLongOptWithArg(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "path/to/app"
 	os.Args[1] = "--alphabet=ABC"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.True(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "ABC")
-	assert.Equal(t, args.OptParams("alphabet"), []string{"ABC"})
-	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.True(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "ABC")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string{"ABC"})
+	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_oneShortOpt(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "path/to/app"
 	os.Args[1] = "-s"
 
 	args, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, args.Name, "app")
+	assert.Equal(t, args.Args(), []string{})
 	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
+	assert.Equal(t, args.OptArg("a"), "")
+	assert.Equal(t, args.OptArgs("a"), []string(nil))
 	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
+	assert.Equal(t, args.OptArg("alphabet"), "")
+	assert.Equal(t, args.OptArgs("alphabet"), []string(nil))
 	assert.True(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string{})
+	assert.Equal(t, args.OptArg("s"), "")
+	assert.Equal(t, args.OptArgs("s"), []string{})
 	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, args.OptArg("silent"), "")
+	assert.Equal(t, args.OptArgs("silent"), []string(nil))
 }
 
-func TestParse_oneShortOptWithParam(t *testing.T) {
+func TestParse_oneShortOptWithArg(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "path/to/app"
 	os.Args[1] = "-a=123"
 
 	args, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{})
+	assert.Equal(t, args.Name, "app")
+	assert.Equal(t, args.Args(), []string{})
 	assert.True(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "123")
-	assert.Equal(t, args.OptParams("a"), []string{"123"})
+	assert.Equal(t, args.OptArg("a"), "123")
+	assert.Equal(t, args.OptArgs("a"), []string{"123"})
 	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
+	assert.Equal(t, args.OptArg("alphabet"), "")
+	assert.Equal(t, args.OptArgs("alphabet"), []string(nil))
 	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
+	assert.Equal(t, args.OptArg("s"), "")
+	assert.Equal(t, args.OptArgs("s"), []string(nil))
 	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, args.OptArg("silent"), "")
+	assert.Equal(t, args.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_oneArgByMultipleShortOpts(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "app"
 	os.Args[1] = "-sa"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, len(args.CmdParams()), 0)
-	assert.True(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string{})
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.True(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string{})
-	assert.False(t, args.HasOpt("silent"))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, len(cmd.Args()), 0)
+	assert.True(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string{})
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.True(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string{})
+	assert.False(t, cmd.HasOpt("silent"))
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.True(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string{})
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.True(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string{})
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.True(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string{})
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.True(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string{})
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
-func TestParse_oneArgByMultipleShortOptsWithParam(t *testing.T) {
+func TestParse_oneArgByMultipleShortOptsWithArg(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "/path/to/app"
 	os.Args[1] = "-sa=123"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.True(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "123")
-	assert.Equal(t, args.OptParams("a"), []string{"123"})
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.True(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string{})
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.True(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "123")
+	assert.Equal(t, cmd.OptArgs("a"), []string{"123"})
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.True(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string{})
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_longOptNameIncludesHyphenMark(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "app"
 	os.Args[1] = "--aaa-bbb-ccc=123"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, len(args.CmdParams()), 0)
-	assert.True(t, args.HasOpt("aaa-bbb-ccc"))
-	assert.Equal(t, args.OptParam("aaa-bbb-ccc"), "123")
-	assert.Equal(t, args.OptParams("aaa-bbb-ccc"), []string{"123"})
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, len(cmd.Args()), 0)
+	assert.True(t, cmd.HasOpt("aaa-bbb-ccc"))
+	assert.Equal(t, cmd.OptArg("aaa-bbb-ccc"), "123")
+	assert.Equal(t, cmd.OptArgs("aaa-bbb-ccc"), []string{"123"})
 }
 
-func TestParse_optParamsIncludesEqualMark(t *testing.T) {
+func TestParse_optsIncludesEqualMark(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "app"
 	os.Args[1] = "-sa=b=c"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.True(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "b=c")
-	assert.Equal(t, args.OptParams("a"), []string{"b=c"})
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.True(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string{})
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.True(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "b=c")
+	assert.Equal(t, cmd.OptArgs("a"), []string{"b=c"})
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.True(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string{})
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
-func TestParse_optParamsIncludesMarks(t *testing.T) {
+func TestParse_optsIncludesMarks(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "path/to/app"
 	os.Args[1] = "-sa=1,2-3"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.True(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "1,2-3")
-	assert.Equal(t, args.OptParams("a"), []string{"1,2-3"})
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.True(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string{})
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.True(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "1,2-3")
+	assert.Equal(t, cmd.OptArgs("a"), []string{"1,2-3"})
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.True(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string{})
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 4)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "app"
 	os.Args[1] = "-s"
 	os.Args[2] = "--abc%def"
 	os.Args[3] = "-a"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:abc%def}")
@@ -308,29 +320,30 @@ func TestParse_illegalLongOptIfIncludingInvalidChar(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "app"
 	os.Args[1] = "--1abc"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:1abc}")
@@ -340,29 +353,30 @@ func TestParse_illegalLongOptIfFirstCharIsNumber(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "app"
 	os.Args[1] = "---aaa=123"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:-aaa=123}")
@@ -372,31 +386,32 @@ func TestParse_illegalLongOptIfFirstCharIsHyphen(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_IllegalCharInShortOpt(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 4)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "path/to/app"
 	os.Args[1] = "-s"
 	os.Args[2] = "--alphabet"
 	os.Args[3] = "-s@"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "OptionHasInvalidChar{Option:@}")
@@ -406,26 +421,27 @@ func TestParse_IllegalCharInShortOpt(t *testing.T) {
 	default:
 		assert.Fail(t, err.Error())
 	}
-	assert.Equal(t, args.CmdParams(), []string{})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "")
+	assert.Equal(t, cmd.Args(), []string{})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_useEndOptMark(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 7)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "app"
 	os.Args[1] = "-s"
 	os.Args[2] = "--"
 	os.Args[3] = "-s"
@@ -433,54 +449,56 @@ func TestParse_useEndOptMark(t *testing.T) {
 	os.Args[5] = "-s@"
 	os.Args[6] = "xxx"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{"-s", "--", "-s@", "xxx"})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.True(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string{})
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{"-s", "--", "-s@", "xxx"})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.True(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string{})
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_singleHyphen(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 2)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "path/to/app"
 	os.Args[1] = "-"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.Equal(t, args.CmdParams(), []string{"-"})
-	assert.False(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string(nil))
-	assert.False(t, args.HasOpt("alphabet"))
-	assert.Equal(t, args.OptParam("alphabet"), "")
-	assert.Equal(t, args.OptParams("alphabet"), []string(nil))
-	assert.False(t, args.HasOpt("s"))
-	assert.Equal(t, args.OptParam("s"), "")
-	assert.Equal(t, args.OptParams("s"), []string(nil))
-	assert.False(t, args.HasOpt("silent"))
-	assert.Equal(t, args.OptParam("silent"), "")
-	assert.Equal(t, args.OptParams("silent"), []string(nil))
+	assert.Equal(t, cmd.Name, "app")
+	assert.Equal(t, cmd.Args(), []string{"-"})
+	assert.False(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string(nil))
+	assert.False(t, cmd.HasOpt("alphabet"))
+	assert.Equal(t, cmd.OptArg("alphabet"), "")
+	assert.Equal(t, cmd.OptArgs("alphabet"), []string(nil))
+	assert.False(t, cmd.HasOpt("s"))
+	assert.Equal(t, cmd.OptArg("s"), "")
+	assert.Equal(t, cmd.OptArgs("s"), []string(nil))
+	assert.False(t, cmd.HasOpt("silent"))
+	assert.Equal(t, cmd.OptArg("silent"), "")
+	assert.Equal(t, cmd.OptArgs("silent"), []string(nil))
 }
 
 func TestParse_multipleArgs(t *testing.T) {
 	defer resetOsArgs()
 
 	os.Args = make([]string, 8)
-	os.Args[0] = osArgs[0]
+	os.Args[0] = "app"
 	os.Args[1] = "--foo-bar"
 	os.Args[2] = "-a"
 	os.Args[3] = "--baz"
@@ -489,23 +507,24 @@ func TestParse_multipleArgs(t *testing.T) {
 	os.Args[6] = "-c=4"
 	os.Args[7] = "quux"
 
-	args, err := cliargs.Parse()
+	cmd, err := cliargs.Parse()
 
 	assert.Nil(t, err)
-	assert.True(t, args.HasOpt("a"))
-	assert.Equal(t, args.OptParam("a"), "")
-	assert.Equal(t, args.OptParams("a"), []string{})
-	assert.True(t, args.HasOpt("b"))
-	assert.Equal(t, args.OptParam("b"), "")
-	assert.Equal(t, args.OptParams("b"), []string{})
-	assert.True(t, args.HasOpt("c"))
-	assert.Equal(t, args.OptParam("c"), "3")
-	assert.Equal(t, args.OptParams("c"), []string{"3", "4"})
-	assert.True(t, args.HasOpt("foo-bar"))
-	assert.Equal(t, args.OptParam("foo-bar"), "")
-	assert.Equal(t, args.OptParams("foo-bar"), []string{})
-	assert.True(t, args.HasOpt("baz"))
-	assert.Equal(t, args.OptParam("baz"), "")
-	assert.Equal(t, args.OptParams("baz"), []string{})
-	assert.Equal(t, args.CmdParams(), []string{"qux", "quux"})
+	assert.Equal(t, cmd.Name, "app")
+	assert.True(t, cmd.HasOpt("a"))
+	assert.Equal(t, cmd.OptArg("a"), "")
+	assert.Equal(t, cmd.OptArgs("a"), []string{})
+	assert.True(t, cmd.HasOpt("b"))
+	assert.Equal(t, cmd.OptArg("b"), "")
+	assert.Equal(t, cmd.OptArgs("b"), []string{})
+	assert.True(t, cmd.HasOpt("c"))
+	assert.Equal(t, cmd.OptArg("c"), "3")
+	assert.Equal(t, cmd.OptArgs("c"), []string{"3", "4"})
+	assert.True(t, cmd.HasOpt("foo-bar"))
+	assert.Equal(t, cmd.OptArg("foo-bar"), "")
+	assert.Equal(t, cmd.OptArgs("foo-bar"), []string{})
+	assert.True(t, cmd.HasOpt("baz"))
+	assert.Equal(t, cmd.OptArg("baz"), "")
+	assert.Equal(t, cmd.OptArgs("baz"), []string{})
+	assert.Equal(t, cmd.Args(), []string{"qux", "quux"})
 }

--- a/print-help.go
+++ b/print-help.go
@@ -93,7 +93,7 @@ func (iter *HelpIter) Next() (string, IterStatus) {
 //
 // A help text consists of an usage section and options section, and options
 // section consists of title parts and description parts.
-// On a title part, a option name, aliases, and a .AtParam field of OptCfg are
+// On a title part, a option name, aliases, and a .HelpArg field of OptCfg are
 // enumerated.
 // On a description part, a .Desc field of OptCfg is put and it follows a title
 // part with an indent, specified in WrapOpts,
@@ -185,8 +185,8 @@ func makeOptTitle(cfg OptCfg) textAndWidth {
 		}
 	}
 
-	if cfg.HasParam && len(cfg.AtParam) > 0 {
-		title += " " + cfg.AtParam
+	if cfg.HasArg && len(cfg.HelpArg) > 0 {
+		title += " " + cfg.HelpArg
 	}
 
 	w := textWidth(title)

--- a/print-help_test.go
+++ b/print-help_test.go
@@ -110,10 +110,10 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_emptyWrapOpts(t *testing.T) {
 			Desc: "This is the description of --foo option.",
 		},
 		OptCfg{
-			Name:     "bar-baz",
-			Aliases:  []string{"b"},
-			HasParam: true,
-			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+			Name:    "bar-baz",
+			Aliases: []string{"b"},
+			HasArg:  true,
+			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
 		},
 	}
 	wrapOpts := WrapOpts{}
@@ -163,10 +163,10 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_largeIndent(t *testing.T) {
 			Desc: "This is the description of --foo option.",
 		},
 		OptCfg{
-			Name:     "bar-baz",
-			Aliases:  []string{"b"},
-			HasParam: true,
-			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+			Name:    "bar-baz",
+			Aliases: []string{"b"},
+			HasArg:  true,
+			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
 		},
 	}
 	wrapOpts := WrapOpts{Indent: 20}
@@ -216,10 +216,10 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_shortIndent(t *testing.T) {
 			Desc: "This is the description of --foo option.",
 		},
 		OptCfg{
-			Name:     "bar-baz",
-			Aliases:  []string{"b"},
-			HasParam: true,
-			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+			Name:    "bar-baz",
+			Aliases: []string{"b"},
+			HasArg:  true,
+			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
 		},
 	}
 	wrapOpts := WrapOpts{Indent: 10}
@@ -273,10 +273,10 @@ func TestMakeHelp_longUsage_twoShortAndLongOptCfg_margins(t *testing.T) {
 			Desc: "This is the description of --foo option.",
 		},
 		OptCfg{
-			Name:     "bar-baz",
-			Aliases:  []string{"b"},
-			HasParam: true,
-			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+			Name:    "bar-baz",
+			Aliases: []string{"b"},
+			HasArg:  true,
+			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
 		},
 	}
 	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5}
@@ -326,10 +326,10 @@ func TestMakeHelp_optNameIsShortAndOptAliasIsLong(t *testing.T) {
 			Desc: "This is the description of --foo option.",
 		},
 		OptCfg{
-			Name:     "b",
-			Aliases:  []string{"bar-baz"},
-			HasParam: true,
-			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+			Name:    "b",
+			Aliases: []string{"bar-baz"},
+			HasArg:  true,
+			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
 		},
 	}
 	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5}
@@ -379,10 +379,10 @@ func TestMakeHelp_marginsAndIndentExceedLineWidth(t *testing.T) {
 			Desc: "This is the description of --foo option.",
 		},
 		OptCfg{
-			Name:     "b",
-			Aliases:  []string{"bar-baz"},
-			HasParam: true,
-			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+			Name:    "b",
+			Aliases: []string{"bar-baz"},
+			HasArg:  true,
+			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
 		},
 	}
 	wrapOpts := WrapOpts{MarginLeft: 50, MarginRight: 50, Indent: 10}
@@ -402,34 +402,34 @@ func TestMakeHelp_marginsAndIndentExceedLineWidth(t *testing.T) {
 	}
 }
 
-func TestMakeHelp_useAtParam(t *testing.T) {
+func TestMakeHelp_useHelpArg(t *testing.T) {
 	usage := longUsage
 	optCfgs := []OptCfg{
 		OptCfg{
-			Name:     "d",
-			Aliases:  []string{"data"},
-			HasParam: true,
-			Desc:     "This is the description of --data option.",
-			AtParam:  "<data>",
+			Name:    "d",
+			Aliases: []string{"data"},
+			HasArg:  true,
+			Desc:    "This is the description of --data option.",
+			HelpArg: "<data>",
 		},
 		OptCfg{
-			Name:     "f",
-			Aliases:  []string{"fail"},
-			HasParam: false,
-			Desc:     "This is the description of --fail option.",
+			Name:    "f",
+			Aliases: []string{"fail"},
+			HasArg:  false,
+			Desc:    "This is the description of --fail option.",
 		},
 		OptCfg{
-			Name:     "o",
-			Aliases:  []string{"output"},
-			HasParam: true,
-			Desc:     "This is the description of --output option.",
-			AtParam:  "<file>",
+			Name:    "o",
+			Aliases: []string{"output"},
+			HasArg:  true,
+			Desc:    "This is the description of --output option.",
+			HelpArg: "<file>",
 		},
 		OptCfg{
-			Name:     "s",
-			Aliases:  []string{"silent"},
-			HasParam: false,
-			Desc:     "This is the description of --silent option.",
+			Name:    "s",
+			Aliases: []string{"silent"},
+			HasArg:  false,
+			Desc:    "This is the description of --silent option.",
 		},
 	}
 	wrapOpts := WrapOpts{}
@@ -486,10 +486,10 @@ func TestPrintHelp(t *testing.T) {
 			Desc: "This is the description of --foo option.",
 		},
 		OptCfg{
-			Name:     "b",
-			Aliases:  []string{"bar-baz"},
-			HasParam: true,
-			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+			Name:    "b",
+			Aliases: []string{"bar-baz"},
+			HasArg:  true,
+			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
 		},
 	}
 	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5, Indent: 10}
@@ -506,10 +506,10 @@ func TestPrintHelp_error(t *testing.T) {
 			Desc: "This is the description of --foo option.",
 		},
 		OptCfg{
-			Name:     "b",
-			Aliases:  []string{"bar-baz"},
-			HasParam: true,
-			Desc:     "This is the description of --bar-baz option. This option takes one parameter.",
+			Name:    "b",
+			Aliases: []string{"bar-baz"},
+			HasArg:  true,
+			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
 		},
 	}
 	wrapOpts := WrapOpts{MarginLeft: 50, MarginRight: 50, Indent: 10}


### PR DESCRIPTION
### Changes:

1. `Args` --> `Cmd`.
2. Changes error reasons:
    1. `ConfigIsArrayButHasNoParam` --> `ConfigIsArrayButHasNoArg`
    2. `ConfigHasDefaultButHasNoParam` --> `ConfigHasDefaultButHasNoArg`
    3. `OptionNeedsParam` --> `OptionNeedsArg`
    4. `OptionTakesNoParam` --> `OptionTakesNoArg`
3. Changes fields of `OptCfg`
    1. `HasParam` --> `HasArg`
    2. `AtParam` --> `HelpArg`
4. Changes struct tags of an option store
    1. `opt` --> `optcfg`
    2. `optparam` --> `optarg`