### PR TITLE
update: changed APIs to print help

### DIFF
--- a/example_parse-for_test.go
+++ b/example_parse-for_test.go
@@ -36,7 +36,7 @@ func ExampleParseFor() {
 	fmt.Printf("optCfgs[1].IsArray = %v\n", optCfgs[1].IsArray)
 	fmt.Printf("optCfgs[1].Default = %v\n", optCfgs[1].Default)
 	fmt.Printf("optCfgs[1].Desc = %v\n", optCfgs[1].Desc)
-	fmt.Printf("optCfgs[1].HelpArg = %v\n", optCfgs[1].HelpArg)
+	fmt.Printf("optCfgs[1].ArgHelp = %v\n", optCfgs[1].ArgHelp)
 
 	fmt.Printf("optCfgs[2].Name = %v\n", optCfgs[2].Name)
 	fmt.Printf("optCfgs[2].Aliases = %v\n", optCfgs[2].Aliases)
@@ -44,7 +44,7 @@ func ExampleParseFor() {
 	fmt.Printf("optCfgs[2].IsArray = %v\n", optCfgs[2].IsArray)
 	fmt.Printf("optCfgs[2].Default = %v\n", optCfgs[2].Default)
 	fmt.Printf("optCfgs[2].Desc = %v\n", optCfgs[2].Desc)
-	fmt.Printf("optCfgs[2].HelpArg = %v\n", optCfgs[2].HelpArg)
+	fmt.Printf("optCfgs[2].ArgHelp = %v\n", optCfgs[2].ArgHelp)
 
 	fmt.Printf("options.FooBar = %v\n", options.FooBar)
 	fmt.Printf("options.Baz = %v\n", options.Baz)
@@ -66,14 +66,14 @@ func ExampleParseFor() {
 	// optCfgs[1].IsArray = false
 	// optCfgs[1].Default = [99]
 	// optCfgs[1].Desc = Baz description.
-	// optCfgs[1].HelpArg = <num>
+	// optCfgs[1].ArgHelp = <num>
 	// optCfgs[2].Name = qux
 	// optCfgs[2].Aliases = [q]
 	// optCfgs[2].HasArg = true
 	// optCfgs[2].IsArray = true
 	// optCfgs[2].Default = [A B C]
 	// optCfgs[2].Desc = Qux description.
-	// optCfgs[2].HelpArg = <text>
+	// optCfgs[2].ArgHelp = <text>
 	// options.FooBar = true
 	// options.Baz = 12
 	// options.Qux = [D E]
@@ -106,7 +106,7 @@ func ExampleMakeOptCfgsFor() {
 	fmt.Printf("optCfgs[1].IsArray = %v\n", optCfgs[1].IsArray)
 	fmt.Printf("optCfgs[1].Default = %v\n", optCfgs[1].Default)
 	fmt.Printf("optCfgs[1].Desc = %v\n", optCfgs[1].Desc)
-	fmt.Printf("optCfgs[1].HelpArg = %v\n", optCfgs[1].HelpArg)
+	fmt.Printf("optCfgs[1].ArgHelp = %v\n", optCfgs[1].ArgHelp)
 	fmt.Println()
 	fmt.Printf("optCfgs[2].Name = %v\n", optCfgs[2].Name)
 	fmt.Printf("optCfgs[2].Aliases = %v\n", optCfgs[2].Aliases)
@@ -114,7 +114,7 @@ func ExampleMakeOptCfgsFor() {
 	fmt.Printf("optCfgs[2].IsArray = %v\n", optCfgs[2].IsArray)
 	fmt.Printf("optCfgs[2].Default = %v\n", optCfgs[2].Default)
 	fmt.Printf("optCfgs[2].Desc = %v\n", optCfgs[2].Desc)
-	fmt.Printf("optCfgs[2].HelpArg = %v\n", optCfgs[2].HelpArg)
+	fmt.Printf("optCfgs[2].ArgHelp = %v\n", optCfgs[2].ArgHelp)
 	fmt.Println()
 	fmt.Printf("optCfgs[3].Name = %v\n", optCfgs[3].Name)
 	fmt.Printf("optCfgs[3].Aliases = %v\n", optCfgs[3].Aliases)
@@ -122,7 +122,7 @@ func ExampleMakeOptCfgsFor() {
 	fmt.Printf("optCfgs[3].IsArray = %v\n", optCfgs[3].IsArray)
 	fmt.Printf("optCfgs[3].Default = %v\n", optCfgs[3].Default)
 	fmt.Printf("optCfgs[3].Desc = %v\n", optCfgs[3].Desc)
-	fmt.Printf("optCfgs[3].HelpArg = %v\n", optCfgs[3].HelpArg)
+	fmt.Printf("optCfgs[3].ArgHelp = %v\n", optCfgs[3].ArgHelp)
 	fmt.Println()
 	fmt.Printf("optCfgs[4].Name = %v\n", optCfgs[4].Name)
 	fmt.Printf("optCfgs[4].Aliases = %v\n", optCfgs[4].Aliases)
@@ -148,7 +148,7 @@ func ExampleMakeOptCfgsFor() {
 	// optCfgs[1].IsArray = false
 	// optCfgs[1].Default = [99]
 	// optCfgs[1].Desc = Baz description
-	// optCfgs[1].HelpArg = <number>
+	// optCfgs[1].ArgHelp = <number>
 	//
 	// optCfgs[2].Name = Qux
 	// optCfgs[2].Aliases = []
@@ -156,7 +156,7 @@ func ExampleMakeOptCfgsFor() {
 	// optCfgs[2].IsArray = false
 	// optCfgs[2].Default = [XXX]
 	// optCfgs[2].Desc = Qux description
-	// optCfgs[2].HelpArg = <string>
+	// optCfgs[2].ArgHelp = <string>
 	//
 	// optCfgs[3].Name = quux
 	// optCfgs[3].Aliases = []
@@ -164,7 +164,7 @@ func ExampleMakeOptCfgsFor() {
 	// optCfgs[3].IsArray = true
 	// optCfgs[3].Default = [A B C]
 	// optCfgs[3].Desc = Quux description
-	// optCfgs[3].HelpArg = <array elem>
+	// optCfgs[3].ArgHelp = <array elem>
 	//
 	// optCfgs[4].Name = Corge
 	// optCfgs[4].Aliases = []

--- a/example_print-help_test.go
+++ b/example_print-help_test.go
@@ -5,48 +5,48 @@ import (
 	"github.com/sttk-go/cliargs"
 )
 
-func ExamplePrintHelp() {
+func ExampleHelp_Print() {
 	type MyOptions struct {
 		FooBar bool     `optcfg:"foo-bar,f" optdesc:"FooBar is a flag.\nThis flag is foo bar."`
-		Baz    int      `optcfg:"baz,b=99" optdesc:"Baz is a integer."`
-		Qux    string   `optcfg:"=XXX" optdesc:"Qux is a string."`
+		Baz    int      `optcfg:"baz,b=99" optdesc:"Baz is a integer." optarg:"<num>"`
+		Qux    string   `optcfg:"=XXX" optdesc:"Qux is a string." optarg:"<text>"`
 		Quux   []string `optcfg:"quux=[A,B,C]" optdesc:"Quux is a string array."`
 	}
 	options := MyOptions{}
 	optCfgs, _ := cliargs.MakeOptCfgsFor(&options)
-	wrapOpts := cliargs.WrapOpts{MarginLeft: 5, MarginRight: 2, Indent: 10}
 
-	usage := "This is the usage section."
-	err := cliargs.PrintHelp(usage, optCfgs, wrapOpts)
-	fmt.Printf("\nerr = %v\n", err)
+	help := cliargs.NewHelp(5, 2)
+	help.AddText("This is the usage section.")
+	help.AddOpts(optCfgs, 10, 1)
+
+	help.Print()
 
 	// Output:
 	//      This is the usage section.
-	//      --foo-bar, -f
-	//                FooBar is a flag.
-	//                This flag is foo bar.
-	//      --baz, -b
-	//                Baz is a integer.
-	//      --Qux     Qux is a string.
-	//      --quux    Quux is a string array.
-	//
-	// err = <nil>
+	//       --foo-bar, -f
+	//                 FooBar is a flag.
+	//                 This flag is foo bar.
+	//       --baz, -b <num>
+	//                 Baz is a integer.
+	//       --Qux <text>
+	//                 Qux is a string.
+	//       --quux    Quux is a string array.
 }
 
-func ExampleMakeHelp() {
+func ExampleHelp_Iter() {
 	type MyOptions struct {
 		FooBar bool     `optcfg:"foo-bar,f" optdesc:"FooBar is a flag.\nThis flag is foo bar."`
-		Baz    int      `optcfg:"baz,b=99" optdesc:"Baz is a integer."`
-		Qux    string   `optcfg:"=XXX" optdesc:"Qux is a string."`
+		Baz    int      `optcfg:"baz,b=99" optdesc:"Baz is a integer." optarg:"<num>"`
+		Qux    string   `optcfg:"=XXX" optdesc:"Qux is a string." optarg:"<text>"`
 		Quux   []string `optcfg:"quux=[A,B,C]" optdesc:"Quux is a string array."`
 	}
 	options := MyOptions{}
 	optCfgs, _ := cliargs.MakeOptCfgsFor(&options)
-	wrapOpts := cliargs.WrapOpts{MarginLeft: 5, MarginRight: 2}
 
-	usage := "This is the usage section."
-	iter, err := cliargs.MakeHelp(usage, optCfgs, wrapOpts)
-	fmt.Printf("\nerr = %v\n", err)
+	help := cliargs.NewHelp(5, 2)
+	help.AddText("This is the usage section.")
+	help.AddOpts(optCfgs, 10, 1)
+	iter := help.Iter()
 
 	for {
 		line, status := iter.Next()
@@ -57,11 +57,13 @@ func ExampleMakeHelp() {
 	}
 
 	// Output:
-	// err = <nil>
 	//      This is the usage section.
-	//      --foo-bar, -f  FooBar is a flag.
-	//                     This flag is foo bar.
-	//      --baz, -b      Baz is a integer.
-	//      --Qux          Qux is a string.
-	//      --quux         Quux is a string array.
+	//       --foo-bar, -f
+	//                 FooBar is a flag.
+	//                 This flag is foo bar.
+	//       --baz, -b <num>
+	//                 Baz is a integer.
+	//       --Qux <text>
+	//                 Qux is a string.
+	//       --quux    Quux is a string array.
 }

--- a/parse-for.go
+++ b/parse-for.go
@@ -225,9 +225,9 @@ func newOptCfg(fld reflect.StructField) OptCfg {
 		}
 	}
 
-	var helpArg string
+	var optArg string
 	if hasArg {
-		helpArg = fld.Tag.Get("optarg")
+		optArg = fld.Tag.Get("optarg")
 	}
 
 	desc := fld.Tag.Get("optdesc")
@@ -239,7 +239,7 @@ func newOptCfg(fld reflect.StructField) OptCfg {
 		IsArray: isArray,
 		Default: defaults,
 		Desc:    desc,
-		HelpArg: helpArg,
+		ArgHelp: optArg,
 	}
 }
 

--- a/parse-for_test.go
+++ b/parse-for_test.go
@@ -1622,11 +1622,11 @@ func TestMakeOptCfgsFor_optionParam(t *testing.T) {
 
 	optCfgs, err0 := cliargs.MakeOptCfgsFor(&options)
 	assert.Nil(t, err0)
-	assert.Equal(t, optCfgs[0].HelpArg, "")
-	assert.Equal(t, optCfgs[1].HelpArg, "bbb")
-	assert.Equal(t, optCfgs[2].HelpArg, "ccc")
-	assert.Equal(t, optCfgs[3].HelpArg, "ddd (multiple)")
-	assert.Equal(t, optCfgs[4].HelpArg, "")
+	assert.Equal(t, optCfgs[0].ArgHelp, "")
+	assert.Equal(t, optCfgs[1].ArgHelp, "bbb")
+	assert.Equal(t, optCfgs[2].ArgHelp, "ccc")
+	assert.Equal(t, optCfgs[3].ArgHelp, "ddd (multiple)")
+	assert.Equal(t, optCfgs[4].ArgHelp, "")
 }
 
 func TestParseFor_optCfgHasUnsupportedType(t *testing.T) {

--- a/parse-with.go
+++ b/parse-with.go
@@ -66,7 +66,7 @@ const anyOption = "*"
 
 // OptCfg is a structure that represents an option configuration.
 // An option configuration consists of fields: Name, Aliases, HasArg,
-// IsArray, Default, OnParsed, Desc, and HelpArg.
+// IsArray, Default, OnParsed, Desc, and ArgHelp.
 //
 // Name is the option name and Aliases are the another names.
 // Options given by those names in command line arguments are all registered to
@@ -92,7 +92,7 @@ const anyOption = "*"
 //
 // Desc is the field to set the description of the option.
 //
-// HelpArg is a display at a argument position of this option in a help text.
+// ArgHelp is a display at a argument position of this option in a help text.
 // This string is for a display like: -o, --option <value>.
 type OptCfg struct {
 	Name     string
@@ -102,7 +102,7 @@ type OptCfg struct {
 	Default  []string
 	OnParsed *func([]string) error
 	Desc     string
-	HelpArg  string
+	ArgHelp  string
 }
 
 // ParseWith is a function which parses command line arguments with option
@@ -115,7 +115,7 @@ type OptCfg struct {
 //
 // This function allows only options declared in option configurations.
 // A option configuration has fields: Name, Aliases, HasArg, IsArray, and
-// Default, HelpArg.
+// Default, ArgHelp.
 // When an option matches Name or includes in Aliases in an option
 // configuration, the option is registered in Args with the Name.
 // If both HasParam and IsArray are true, the option can has one or multiple

--- a/print-help.go
+++ b/print-help.go
@@ -51,12 +51,7 @@ func (help Help) Iter() HelpIter {
 	return HelpIter{
 		lineWidth: lineWidth,
 		blocks:    help.blocks,
-		blockIter: newBlockIter(
-			help.blocks[0].texts,
-			lineWidth-help.blocks[0].marginLeft-help.blocks[0].marginRight,
-			help.blocks[0].indent,
-			help.blocks[0].marginLeft,
-		),
+		blockIter: newBlockIter(help.blocks[0], lineWidth),
 	}
 }
 
@@ -78,12 +73,7 @@ func (iter *HelpIter) Next() (string, IterStatus) {
 			return line, ITER_NO_MORE
 		}
 		iter.blocks = iter.blocks[1:]
-		iter.blockIter = newBlockIter(
-			iter.blocks[0].texts,
-			iter.lineWidth-iter.blocks[0].marginLeft-iter.blocks[0].marginRight,
-			iter.blocks[0].indent,
-			iter.blocks[0].marginLeft,
-		)
+		iter.blockIter = newBlockIter(iter.blocks[0], iter.lineWidth)
 	}
 	return line, ITER_HAS_MORE
 }
@@ -96,15 +86,19 @@ type blockIter struct {
 	lineIter lineIter
 }
 
-func newBlockIter(texts []string, lineWidth, indent, margin int) blockIter {
-	if len(texts) == 0 {
+func newBlockIter(b block, lineWidth int) blockIter {
+	if len(b.texts) == 0 {
+		return blockIter{}
+	}
+	printWidth := lineWidth - b.marginLeft - b.marginRight
+	if printWidth <= b.indent {
 		return blockIter{}
 	}
 	return blockIter{
-		texts:    texts,
-		indent:   indent,
-		margin:   strings.Repeat(" ", margin),
-		lineIter: newLineIter(texts[0], lineWidth),
+		texts:    b.texts,
+		indent:   b.indent,
+		margin:   strings.Repeat(" ", b.marginLeft),
+		lineIter: newLineIter(b.texts[0], printWidth),
 	}
 }
 

--- a/print-help.go
+++ b/print-help.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 )
 
+// Help is a struct type which holds help text blocks and help options block.
 type Help struct {
 	marginLeft, marginRight int
 	blocks                  []block
@@ -21,6 +22,9 @@ type block struct {
 	texts                           []string
 }
 
+// NewHelp is a function to create a Help instance.
+// This function can optionally take left margin and right margin as variadic
+// arguments.
 func NewHelp(wrapOpts ...int) Help {
 	var help Help
 	if len(wrapOpts) > 0 {
@@ -33,6 +37,7 @@ func NewHelp(wrapOpts ...int) Help {
 	return help
 }
 
+// Iter is a method which creates a HelpIter instance.
 func (help Help) Iter() HelpIter {
 	if len(help.blocks) == 0 {
 		return HelpIter{}
@@ -55,12 +60,17 @@ func (help Help) Iter() HelpIter {
 	}
 }
 
+// HelpIter is a struct type to iterate lines of help texts.
 type HelpIter struct {
 	lineWidth int
 	blocks    []block
 	blockIter blockIter
 }
 
+// Next is a method which returns a line of a help text and a status which
+// indicates this HelpIter has more texts or not.
+// If there are more lines, the returned IterStatus value is ITER_HAS_MORE,
+// otherwise the value is ITER_NO_MORE.
 func (iter *HelpIter) Next() (string, IterStatus) {
 	line, status := iter.blockIter.next()
 	if status == ITER_NO_MORE {
@@ -121,6 +131,9 @@ func (iter *blockIter) next() (string, IterStatus) {
 	return line, status
 }
 
+// AddText is a method which adds a text to this Help instance.
+// And this method can optionally set indent, left margin, and right margin as
+// variadic arguments, too.
 func (help *Help) AddText(text string, wrapOpts ...int) {
 	b := block{
 		marginLeft:  help.marginLeft,
@@ -139,6 +152,9 @@ func (help *Help) AddText(text string, wrapOpts ...int) {
 	help.blocks = append(help.blocks, b)
 }
 
+// AddOpts is a method which adds OptCfg(s) to this Help instance.
+// And this method can optionally set indent, left margin, and right margin as
+// variadic arguments, too.
 func (help *Help) AddOpts(optCfgs []OptCfg, wrapOpts ...int) {
 	b := block{
 		marginLeft:  help.marginLeft,
@@ -243,6 +259,7 @@ func textWidth(text string) int {
 	return w
 }
 
+// Print is a method which prints help texts to standard output.
 func (help Help) Print() {
 	iter := help.Iter()
 

--- a/print-help_test.go
+++ b/print-help_test.go
@@ -1,7 +1,6 @@
 package cliargs_test
 
 import (
-	//"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/sttk-go/cliargs"
 	"testing"

--- a/print-help_test.go
+++ b/print-help_test.go
@@ -1,573 +1,583 @@
-package cliargs
+package cliargs_test
 
 import (
-	"fmt"
+	//"fmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/sttk-go/cliargs"
 	"testing"
 )
 
-func TestMakeHelp_emptyUsage_noOptCfg_emptyWrapOpts(t *testing.T) {
-	optCfgs := []OptCfg{}
-	wrapOpts := WrapOpts{}
-
-	iter, err := MakeHelp("", optCfgs, wrapOpts)
-	assert.Nil(t, err)
+func TestNewHelp_empty(t *testing.T) {
+	help := cliargs.NewHelp()
+	iter := help.Iter()
 
 	line, status := iter.Next()
 	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 
 	line, status = iter.Next()
 	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 }
 
-func TestMakeHelp_shortUsage_noOptCfg_emptyWrapOpts(t *testing.T) {
-	usage := "abcdefghijklmnopqrstuvwxyz"
-	optCfgs := []OptCfg{}
-	wrapOpts := WrapOpts{}
-
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
+func TestAddText_oneLine_withNoWrapping(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddText("abc")
+	iter := help.Iter()
 
 	line, status := iter.Next()
-	assert.Equal(t, line, usage)
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "abc")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 
 	line, status = iter.Next()
 	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 }
 
-// This text is quoted from https://go.dev/doc/
-const longUsage string = "The Go programming language is an open source project to make programmers more productive."
-
-func TestMakeHelp_longUsage_noOptCfg_emptyWrapOpts(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{}
-	wrapOpts := WrapOpts{}
-
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
+func TestAddText_multiLines_withNoWrapping(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddText("abc\ndef")
+	iter := help.Iter()
 
 	line, status := iter.Next()
-	assert.Equal(t, line, usage[0:79])
-	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "abc")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, usage[79:90])
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "def")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 
 	line, status = iter.Next()
 	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 }
 
-func TestMakeHelp_longUsage_oneShortOptCfg_emptyWrapOpts(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
-			Name: "foo",
-			Desc: "This is the description of --foo option.",
+func TestAddText_oneLine_withWrapping(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddText("a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789i12345")
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "i12345")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddText_multiLines_withWrapping(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddText("a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789i12345\n6789j123456789k123456789l123456789m123456789n123456789o123456789p123456789q12345678")
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "i12345")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "6789j123456789k123456789l123456789m123456789n123456789o123456789p123456789q12345")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddText_marginLeftByNewArgHelp(t *testing.T) {
+	help := cliargs.NewHelp(5)
+	help.AddText("abc\ndef")
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "     abc")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     def")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddText_marginLeftAndMarginRightByNewArgHelps(t *testing.T) {
+	help := cliargs.NewHelp(5, 3)
+	help.AddText("a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789i12345\n6789")
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "     a123456789b123456789c123456789d123456789e123456789f123456789g123456789h1")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     23456789i12345")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     6789")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddText_marginLeftByiAddHelpTextArg(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddText("abc\ndef", 0, 5)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "     abc")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     def")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddText_marginLeftAndMarginRightByddHelpTextArgs(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddText("a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789i12345\n6789", 0, 5, 3)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "     a123456789b123456789c123456789d123456789e123456789f123456789g123456789h1")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     23456789i12345")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     6789")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddText_Indent(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddText("a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789i12345\n6789", 8)
+	help.AddText("a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789i12345\n6789", 5)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "        i12345")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "        6789")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "a123456789b123456789c123456789d123456789e123456789f123456789g123456789h123456789")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     i12345")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "     6789")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddOpts_zeroOpts(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddOpts([]cliargs.OptCfg{})
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddOpts_oneOpts_withNoWrapping(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name: "foo-bar",
+			Desc: "This is a description of option.",
 		},
-	}
-	wrapOpts := WrapOpts{}
-
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
+	})
+	iter := help.Iter()
 
 	line, status := iter.Next()
-	assert.Equal(t, line, usage[0:79])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, usage[79:90])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "--foo  This is the description of --foo option.")
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "--foo-bar  This is a description of option.")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 
 	line, status = iter.Next()
 	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
-
-	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
-	for {
-		line, status = iter.Next()
-		fmt.Println(line)
-		if status == ITER_NO_MORE {
-			break
-		}
-	}
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 }
 
-func TestMakeHelp_longUsage_twoShortAndLongOptCfg_emptyWrapOpts(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
-			Name: "foo",
-			Desc: "This is the description of --foo option.",
+func TestAddOpts_oneOpts_withWrapping(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name:    "foo-bar",
+			Aliases: []string{"f", "foo", "b", "bar"},
+			Desc:    "a12345678 b12345678 c12345678 d12345678 e12345678 f12345678 g12345678",
 		},
-		OptCfg{
-			Name:    "bar-baz",
+	})
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "--foo-bar, -f, --foo, -b, --bar  a12345678 b12345678 c12345678 d12345678 ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                                 e12345678 f12345678 g12345678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddOpts_oneOpts_withMarginsByNewHelpArg(t *testing.T) {
+	help := cliargs.NewHelp(5, 3)
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name:    "foo-bar",
+			Aliases: []string{"f"},
+			HasArg:  true,
+			Desc:    "a12345678 b12345678 c12345678 d12345678 e12345678 f12345678 g12345678 h12345678",
+			ArgHelp: "<text>",
+		},
+	})
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "     --foo-bar, -f <text>  a12345678 b12345678 c12345678 d12345678 e12345678 ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                           f12345678 g12345678 h12345678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddOpts_oneOpts_withMarginsByAddOptsArg(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name:    "foo-bar",
+			Aliases: []string{"f"},
+			HasArg:  true,
+			Desc:    "a12345678 b12345678 c12345678 d12345678 e12345678 f12345678 g12345678 h12345678",
+			ArgHelp: "<text>",
+		},
+	}, 0, 5, 3)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "     --foo-bar, -f <text>  a12345678 b12345678 c12345678 d12345678 e12345678 ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                           f12345678 g12345678 h12345678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddOpts_oneOpts_withMarginsByNewHelpArgAndAddOptsArg(t *testing.T) {
+	help := cliargs.NewHelp(2, 2)
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name:    "foo-bar",
+			Aliases: []string{"f"},
+			HasArg:  true,
+			Desc:    "a12345678 b12345678 c12345678 d12345678 e12345678 f12345678 g12345678 h12345678",
+			ArgHelp: "<text>",
+		},
+	}, 0, 3, 1)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "     --foo-bar, -f <text>  a12345678 b12345678 c12345678 d12345678 e12345678 ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                           f12345678 g12345678 h12345678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddOpts_oneOpts_withIndentLongerThanTitle(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name:    "foo-bar",
+			Aliases: []string{"f"},
+			HasArg:  true,
+			Desc:    "a12345678 b12345678 c12345678 d12345678 e12345678 f12345678 g12345678 h12345678",
+			ArgHelp: "<text>",
+		},
+	}, 25)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "--foo-bar, -f <text>     a12345678 b12345678 c12345678 d12345678 e12345678 ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                         f12345678 g12345678 h12345678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddOpts_oneOpts_withIndentShorterThanTitle(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name:    "foo-bar",
+			Aliases: []string{"f"},
+			HasArg:  true,
+			Desc:    "a12345678 b12345678 c12345678 d12345678 e12345678 f12345678 g12345678 h12345678",
+			ArgHelp: "<text>",
+		},
+	}, 10)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "--foo-bar, -f <text>")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "          a12345678 b12345678 c12345678 d12345678 e12345678 f12345678 g12345678 ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "          h12345678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddOpts_multipleOpts(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name:    "foo-bar",
+			Aliases: []string{"f"},
+			HasArg:  true,
+			Desc:    "a12345678 b12345678 c12345678 d12345678 e12345678 f12345678 g12345678 h12345678",
+			ArgHelp: "<text>",
+		},
+		cliargs.OptCfg{
+			Name:    "baz",
 			Aliases: []string{"b"},
-			HasArg:  true,
-			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
+			Desc:    "i12345678 j12345678 k12345678 l12345678 m12345678 n12345678 o12345678 p12345678",
 		},
-	}
-	wrapOpts := WrapOpts{}
-
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
+	})
+	iter := help.Iter()
 
 	line, status := iter.Next()
-	assert.Equal(t, line, usage[0:79])
-	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "--foo-bar, -f <text>  a12345678 b12345678 c12345678 d12345678 e12345678 ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, usage[79:90])
-	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "                      f12345678 g12345678 h12345678")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, "--foo          This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "--baz, -b             i12345678 j12345678 k12345678 l12345678 m12345678 ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, "--bar-baz, -b  This is the description of --bar-baz option. This option takes ")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "               one parameter.")
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "                      n12345678 o12345678 p12345678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 
 	line, status = iter.Next()
 	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
-
-	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
-	for {
-		line, status = iter.Next()
-		fmt.Println(line)
-		if status == ITER_NO_MORE {
-			break
-		}
-	}
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 }
 
-func TestMakeHelp_longUsage_twoShortAndLongOptCfg_largeIndent(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
-			Name: "foo",
-			Desc: "This is the description of --foo option.",
+func TestAddOpts_hasAnyOption(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name: "foo-bar",
+			Desc: "a12345678 b12345678",
 		},
-		OptCfg{
-			Name:    "bar-baz",
-			Aliases: []string{"b"},
-			HasArg:  true,
-			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
+		cliargs.OptCfg{
+			Name: "*",
+			Desc: "c12345678 d12345678",
 		},
-	}
-	wrapOpts := WrapOpts{Indent: 20}
-
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
+	})
+	iter := help.Iter()
 
 	line, status := iter.Next()
-	assert.Equal(t, line, usage[0:79])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, usage[79:90])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "--foo               This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "--bar-baz, -b       This is the description of --bar-baz option. This option ")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "                    takes one parameter.")
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "--foo-bar  a12345678 b12345678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 
 	line, status = iter.Next()
 	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
-
-	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
-	for {
-		line, status = iter.Next()
-		fmt.Println(line)
-		if status == ITER_NO_MORE {
-			break
-		}
-	}
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 }
 
-func TestMakeHelp_longUsage_twoShortAndLongOptCfg_shortIndent(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
-			Name: "foo",
-			Desc: "This is the description of --foo option.",
+func TestAddOpts_hasAnyOption_withIndent(t *testing.T) {
+	help := cliargs.NewHelp()
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name: "*",
+			Desc: "c12345678 d12345678",
 		},
-		OptCfg{
-			Name:    "bar-baz",
-			Aliases: []string{"b"},
-			HasArg:  true,
-			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
+		cliargs.OptCfg{
+			Name: "foo-bar",
+			Desc: "a12345678 b12345678",
 		},
-	}
-	wrapOpts := WrapOpts{Indent: 10}
-
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
+	}, 5)
+	iter := help.Iter()
 
 	line, status := iter.Next()
-	assert.Equal(t, line, usage[0:79])
-	assert.Equal(t, status, ITER_HAS_MORE)
+	assert.Equal(t, line, "--foo-bar")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
 
 	line, status = iter.Next()
-	assert.Equal(t, line, usage[79:90])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "--foo     This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "--bar-baz, -b")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "          This is the description of --bar-baz option. This option takes one ")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "          parameter.")
-	assert.Equal(t, status, ITER_NO_MORE)
+	assert.Equal(t, line, "     a12345678 b12345678")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 
 	line, status = iter.Next()
 	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
-
-	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
-	for {
-		line, status = iter.Next()
-		fmt.Println(line)
-		if status == ITER_NO_MORE {
-			break
-		}
-	}
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 }
 
-func TestMakeHelp_longUsage_twoShortAndLongOptCfg_margins(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
-			Name: "foo",
-			Desc: "This is the description of --foo option.",
-		},
-		OptCfg{
-			Name:    "bar-baz",
-			Aliases: []string{"b"},
-			HasArg:  true,
-			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
-		},
-	}
-	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5}
+func TestPrint_curl(t *testing.T) {
+	// The source of the following text is the output of `curl --help` in curl 7.87.0
+	// https://curl.se/docs/copyright.html
 
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
+	help := cliargs.NewHelp()
 
-	line, status := iter.Next()
-	assert.Equal(t, line, "     "+usage[0:62])
-	assert.Equal(t, status, ITER_HAS_MORE)
+	help.AddText("Usage: curl [options...] <url>")
 
-	line, status = iter.Next()
-	assert.Equal(t, line, "     "+usage[62:90])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "     --foo          This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "     --bar-baz, -b  This is the description of --bar-baz option. This ")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "                    option takes one parameter.")
-	assert.Equal(t, status, ITER_NO_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
-
-	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
-	for {
-		line, status = iter.Next()
-		fmt.Println(line)
-		if status == ITER_NO_MORE {
-			break
-		}
-	}
-}
-
-func TestMakeHelp_optNameIsShortAndOptAliasIsLong(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
-			Name: "foo",
-			Desc: "This is the description of --foo option.",
-		},
-		OptCfg{
-			Name:    "b",
-			Aliases: []string{"bar-baz"},
-			HasArg:  true,
-			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
-		},
-	}
-	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5}
-
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
-
-	line, status := iter.Next()
-	assert.Equal(t, line, "     "+usage[0:62])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "     "+usage[62:90])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "     --foo          This is the description of --foo option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "     -b, --bar-baz  This is the description of --bar-baz option. This ")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "                    option takes one parameter.")
-	assert.Equal(t, status, ITER_NO_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
-
-	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
-	for {
-		line, status = iter.Next()
-		fmt.Println(line)
-		if status == ITER_NO_MORE {
-			break
-		}
-	}
-}
-
-func TestMakeHelp_marginsAndIndentExceedLineWidth(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
-			Name: "foo",
-			Desc: "This is the description of --foo option.",
-		},
-		OptCfg{
-			Name:    "b",
-			Aliases: []string{"bar-baz"},
-			HasArg:  true,
-			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
-		},
-	}
-	wrapOpts := WrapOpts{MarginLeft: 50, MarginRight: 50, Indent: 10}
-
-	_, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "MarginsAndIndentExceedLineWidth{"+
-		"LineWidth:80,MarginLeft:50,MarginRight:50,Indent:10}")
-	switch err.(type) {
-	case MarginsAndIndentExceedLineWidth:
-		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).LineWidth, 80)
-		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).MarginLeft, 50)
-		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).MarginRight, 50)
-		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).Indent, 10)
-	default:
-		assert.Fail(t, err.Error())
-	}
-}
-
-func TestMakeHelp_useHelpArg(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
 			Name:    "d",
 			Aliases: []string{"data"},
+			Desc:    "HTTP POST data",
 			HasArg:  true,
-			Desc:    "This is the description of --data option.",
-			HelpArg: "<data>",
+			ArgHelp: "<data>",
 		},
-		OptCfg{
+		cliargs.OptCfg{
 			Name:    "f",
 			Aliases: []string{"fail"},
-			HasArg:  false,
-			Desc:    "This is the description of --fail option.",
+			Desc:    "Fail fast with no output on HTTP errors",
 		},
-		OptCfg{
+		cliargs.OptCfg{
+			Name:    "h",
+			Aliases: []string{"help"},
+			Desc:    "Get help for commands",
+			HasArg:  true,
+			ArgHelp: "<category>",
+		},
+		cliargs.OptCfg{
+			Name:    "i",
+			Aliases: []string{"include"},
+			Desc:    "Include protocol response headers in the output",
+		},
+		cliargs.OptCfg{
 			Name:    "o",
 			Aliases: []string{"output"},
+			Desc:    "Write to file instead of stdout",
 			HasArg:  true,
-			Desc:    "This is the description of --output option.",
-			HelpArg: "<file>",
+			ArgHelp: "<file>",
 		},
-		OptCfg{
+		cliargs.OptCfg{
+			Name:    "O",
+			Aliases: []string{"remote-name"},
+			Desc:    "Write output to a file named as the remote file",
+		},
+		cliargs.OptCfg{
 			Name:    "s",
 			Aliases: []string{"silent"},
-			HasArg:  false,
-			Desc:    "This is the description of --silent option.",
+			Desc:    "Silent mode",
 		},
-	}
-	wrapOpts := WrapOpts{}
-
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
-
-	line, status := iter.Next()
-	assert.Equal(t, line, usage[0:79])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, usage[79:90])
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "-d, --data <data>    This is the description of --data option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "-f, --fail           This is the description of --fail option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "-o, --output <file>  This is the description of --output option.")
-	assert.Equal(t, status, ITER_HAS_MORE)
-
-	line, status = iter.Next()
-	assert.Equal(t, line, "-s, --silent         This is the description of --silent option.")
-	assert.Equal(t, status, ITER_NO_MORE)
-
-	iter, _ = MakeHelp(usage, optCfgs, wrapOpts)
-	for {
-		line, status = iter.Next()
-		fmt.Println(line)
-		if status == ITER_NO_MORE {
-			break
-		}
-	}
-}
-
-func TestHelpIter_textsIsEmpty(t *testing.T) {
-	iter := newHelpIter([]string{}, 0, 0, 0)
-	line, status := iter.Next()
-	assert.Equal(t, line, "")
-	assert.Equal(t, status, ITER_NO_MORE)
-}
-
-func TestPrintHelp(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
-			Name: "foo",
-			Desc: "This is the description of --foo option.",
-		},
-		OptCfg{
-			Name:    "b",
-			Aliases: []string{"bar-baz"},
+		cliargs.OptCfg{
+			Name:    "T",
+			Aliases: []string{"upload-file"},
+			Desc:    "Transfer local FILE to destination",
 			HasArg:  true,
-			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
+			ArgHelp: "<file>",
 		},
-	}
-	wrapOpts := WrapOpts{MarginLeft: 5, MarginRight: 5, Indent: 10}
-
-	err := PrintHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
-}
-
-func TestPrintHelp_error(t *testing.T) {
-	usage := longUsage
-	optCfgs := []OptCfg{
-		OptCfg{
-			Name: "foo",
-			Desc: "This is the description of --foo option.",
-		},
-		OptCfg{
-			Name:    "b",
-			Aliases: []string{"bar-baz"},
+		cliargs.OptCfg{
+			Name:    "u",
+			Aliases: []string{"user"},
+			Desc:    "Server user and password",
 			HasArg:  true,
-			Desc:    "This is the description of --bar-baz option. This option takes one parameter.",
+			ArgHelp: "<user:password>",
 		},
-	}
-	wrapOpts := WrapOpts{MarginLeft: 50, MarginRight: 50, Indent: 10}
+		cliargs.OptCfg{
+			Name:    "A",
+			Aliases: []string{"user-agent"},
+			Desc:    "Send User-Agent <name> to server",
+			HasArg:  true,
+			ArgHelp: "<name>",
+		},
+		cliargs.OptCfg{
+			Name:    "v",
+			Aliases: []string{"verbose"},
+			Desc:    "Make the operation more talkative",
+		},
+		cliargs.OptCfg{
+			Name:    "V",
+			Aliases: []string{"version"},
+			Desc:    "Show version number and quit",
+		},
+	}, 0, 1)
 
-	err := PrintHelp(usage, optCfgs, wrapOpts)
-	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "MarginsAndIndentExceedLineWidth{"+
-		"LineWidth:80,MarginLeft:50,MarginRight:50,Indent:10}")
-	switch err.(type) {
-	case MarginsAndIndentExceedLineWidth:
-		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).LineWidth, 80)
-		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).MarginLeft, 50)
-		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).MarginRight, 50)
-		assert.Equal(t, err.(MarginsAndIndentExceedLineWidth).Indent, 10)
-	default:
-		assert.Fail(t, err.Error())
-	}
-}
+	help.AddText(`
+This is not the full help, this menu is stripped into categories.
+Use "--help category" to get an overview of all categories.
+For all options use the manual or "--help all".`)
 
-func TestMakeHelp_optCfgsIncludesAnyOption(t *testing.T) {
-	usage := "abcdefg"
-	optCfgs := []OptCfg{
-		OptCfg{Name: "foo", Desc: "description of foo."},
-		OptCfg{Name: "bar-baz", Desc: "description of bar-baz."},
-		OptCfg{Name: "*", Desc: "description of *."},
-		OptCfg{Name: "qux", Desc: "description of qux."},
-	}
-	wrapOpts := WrapOpts{}
-
-	iter, err := MakeHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
-	text, status := iter.Next()
-	assert.Equal(t, status, ITER_HAS_MORE)
-	assert.Equal(t, text, usage)
-	text, status = iter.Next()
-	assert.Equal(t, status, ITER_HAS_MORE)
-	assert.Equal(t, text, "--foo      description of foo.")
-	text, status = iter.Next()
-	assert.Equal(t, status, ITER_HAS_MORE)
-	assert.Equal(t, text, "--bar-baz  description of bar-baz.")
-	text, status = iter.Next()
-	assert.Equal(t, status, ITER_NO_MORE)
-	assert.Equal(t, text, "--qux      description of qux.")
-	text, status = iter.Next()
-	assert.Equal(t, status, ITER_NO_MORE)
-	assert.Equal(t, text, "")
-}
-
-func TestPrintHelp_optCfgsIncludesAnyOption(t *testing.T) {
-	usage := "abcdefg"
-	optCfgs := []OptCfg{
-		OptCfg{Name: "foo", Desc: "description of foo."},
-		OptCfg{Name: "bar-baz", Desc: "description of bar-baz."},
-		OptCfg{Name: "*", Desc: "description of *."},
-		OptCfg{Name: "qux", Desc: "description of qux."},
-	}
-	wrapOpts := WrapOpts{MarginLeft: 5}
-
-	err := PrintHelp(usage, optCfgs, wrapOpts)
-	assert.Nil(t, err)
+	help.Print()
 }

--- a/print-help_test.go
+++ b/print-help_test.go
@@ -490,9 +490,93 @@ func TestAddOpts_hasAnyOption_withIndent(t *testing.T) {
 	assert.Equal(t, status, cliargs.ITER_NO_MORE)
 }
 
+func TestNewHelp_ifLineWidthLessThanSumOfMargins(t *testing.T) {
+	help := cliargs.NewHelp(71, 10)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddText_ifLineWidthLessThanSumOfMargins(t *testing.T) {
+	help := cliargs.NewHelp(10, 40)
+	help.AddText("abcdefg", 10, 10, 10)
+	help.AddText("hijklmn", 10, 10)
+	help.AddText("opqrstu", 10, 10, 11)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                    hijklmn")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
+func TestAddOpts_ifLineWidthLessThanSunOfMargins(t *testing.T) {
+	help := cliargs.NewHelp(10, 30)
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name: "foo-bar",
+			Desc: "This is a description of option.",
+		},
+	}, 10, 10, 20)
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name: "baz",
+			Desc: "This is a description of option.",
+		},
+	}, 10, 10)
+	help.AddOpts([]cliargs.OptCfg{
+		cliargs.OptCfg{
+			Name: "qux",
+			Desc: "This is a description of option.",
+		},
+	}, 10, 10, 21)
+	iter := help.Iter()
+
+	line, status := iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                    --baz     This is a ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                              description of ")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "                              option.")
+	assert.Equal(t, status, cliargs.ITER_HAS_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+
+	line, status = iter.Next()
+	assert.Equal(t, line, "")
+	assert.Equal(t, status, cliargs.ITER_NO_MORE)
+}
+
 func TestPrint_curl(t *testing.T) {
-	// The source of the following text is the output of `curl --help` in curl 7.87.0
-	// https://curl.se/docs/copyright.html
+	// The source of the following text is the output of `curl --help` in
+	// curl 7.87.0. (https://curl.se/docs/copyright.html)
 
 	help := cliargs.NewHelp()
 


### PR DESCRIPTION
This PR deprecated `PrintHelp` function and `WrapOpts` struct.
Instead, this PR adds `Help` struct and its methods: `Help#Iter` and `Help#Print`.

In addition, this PR renames the field of `OptCfg`: `.HelpArg` to `.ArgHelp`.





Closes #26 